### PR TITLE
Fix native ARM64 buildpack builds

### DIFF
--- a/control-plane/build.gradle
+++ b/control-plane/build.gradle
@@ -138,9 +138,13 @@ tasks.named('aotTestClasses') { enabled = false }
 
 bootBuildImage {
     imageName = project.findProperty('controlPlaneImage') ?: (System.getenv('CONTROL_PLANE_IMAGE') ?: 'nanofaas/control-plane:buildpack')
-    // Use tiny builder optimized for native images
-    builder = 'paketobuildpacks/builder-jammy-tiny:latest'
-    runImage = 'paketobuildpacks/run-jammy-tiny:latest'
+    // Builder/run image are overrideable to support multi-arch native builds (e.g., ARM64 on Apple Silicon).
+    def builderImage = (project.findProperty('imageBuilder') ?: System.getenv('IMAGE_BUILDER')
+            ?: 'paketobuildpacks/builder-jammy-tiny:latest').toString()
+    def runImageName = (project.findProperty('imageRunImage') ?: System.getenv('IMAGE_RUN_IMAGE')
+            ?: 'paketobuildpacks/run-jammy-tiny:latest').toString()
+    builder = builderImage
+    runImage = runImageName
     // Target platform for cross-compilation (e.g., linux/amd64, linux/arm64)
     def targetPlatform = project.findProperty('imagePlatform') ?: System.getenv('IMAGE_PLATFORM')
     if (targetPlatform) {

--- a/examples/java/json-transform/build.gradle
+++ b/examples/java/json-transform/build.gradle
@@ -21,7 +21,16 @@ bootJar {
 
 bootBuildImage {
     imageName = project.findProperty('functionImage') ?: 'nanofaas/java-json-transform:buildpack'
-    builder = 'paketobuildpacks/builder-jammy-tiny:latest'
-    runImage = 'paketobuildpacks/run-jammy-tiny:latest'
+    def builderImage = (project.findProperty('imageBuilder') ?: System.getenv('IMAGE_BUILDER')
+            ?: 'paketobuildpacks/builder-jammy-tiny:latest').toString()
+    def runImageName = (project.findProperty('imageRunImage') ?: System.getenv('IMAGE_RUN_IMAGE')
+            ?: 'paketobuildpacks/run-jammy-tiny:latest').toString()
+    builder = builderImage
+    runImage = runImageName
+    // Target platform for cross-compilation (e.g., linux/amd64, linux/arm64)
+    def targetPlatform = project.findProperty('imagePlatform') ?: System.getenv('IMAGE_PLATFORM')
+    if (targetPlatform) {
+        imagePlatform = targetPlatform
+    }
     environment = ['BP_NATIVE_IMAGE': 'true']
 }

--- a/examples/java/word-stats/build.gradle
+++ b/examples/java/word-stats/build.gradle
@@ -21,7 +21,16 @@ bootJar {
 
 bootBuildImage {
     imageName = project.findProperty('functionImage') ?: 'nanofaas/java-word-stats:buildpack'
-    builder = 'paketobuildpacks/builder-jammy-tiny:latest'
-    runImage = 'paketobuildpacks/run-jammy-tiny:latest'
+    def builderImage = (project.findProperty('imageBuilder') ?: System.getenv('IMAGE_BUILDER')
+            ?: 'paketobuildpacks/builder-jammy-tiny:latest').toString()
+    def runImageName = (project.findProperty('imageRunImage') ?: System.getenv('IMAGE_RUN_IMAGE')
+            ?: 'paketobuildpacks/run-jammy-tiny:latest').toString()
+    builder = builderImage
+    runImage = runImageName
+    // Target platform for cross-compilation (e.g., linux/amd64, linux/arm64)
+    def targetPlatform = project.findProperty('imagePlatform') ?: System.getenv('IMAGE_PLATFORM')
+    if (targetPlatform) {
+        imagePlatform = targetPlatform
+    }
     environment = ['BP_NATIVE_IMAGE': 'true']
 }

--- a/function-runtime/build.gradle
+++ b/function-runtime/build.gradle
@@ -31,9 +31,13 @@ tasks.named('aotTestClasses') { enabled = false }
 
 bootBuildImage {
     imageName = project.findProperty('functionRuntimeImage') ?: (System.getenv('FUNCTION_RUNTIME_IMAGE') ?: 'nanofaas/function-runtime:buildpack')
-    // Use tiny builder optimized for native images
-    builder = 'paketobuildpacks/builder-jammy-tiny:latest'
-    runImage = 'paketobuildpacks/run-jammy-tiny:latest'
+    // Builder/run image are overrideable to support multi-arch native builds (e.g., ARM64 on Apple Silicon).
+    def builderImage = (project.findProperty('imageBuilder') ?: System.getenv('IMAGE_BUILDER')
+            ?: 'paketobuildpacks/builder-jammy-tiny:latest').toString()
+    def runImageName = (project.findProperty('imageRunImage') ?: System.getenv('IMAGE_RUN_IMAGE')
+            ?: 'paketobuildpacks/run-jammy-tiny:latest').toString()
+    builder = builderImage
+    runImage = runImageName
     // Target platform for cross-compilation (e.g., linux/amd64, linux/arm64)
     def targetPlatform = project.findProperty('imagePlatform') ?: System.getenv('IMAGE_PLATFORM')
     if (targetPlatform) {


### PR DESCRIPTION
Fixes local ARM64 release builds on Apple Silicon.

- Paketo `builder-jammy-tiny` is amd64-only; make builder/run image overrideable and use `dashaun/builder:tiny` for ARM64 native builds in the release manager.
- Thread `imagePlatform` / `imageBuilder` / `imageRunImage` through `bootBuildImage` for control-plane, function-runtime, and Java examples.
- Add a best-effort retry on `No space left on device` by pruning build caches.
