### PR TITLE
Add cold start metrics and e2e verification script

### DIFF
--- a/common/src/main/java/it/unimib/datai/nanofaas/common/model/ExecutionStatus.java
+++ b/common/src/main/java/it/unimib/datai/nanofaas/common/model/ExecutionStatus.java
@@ -8,6 +8,8 @@ public record ExecutionStatus(
         Instant startedAt,
         Instant finishedAt,
         Object output,
-        ErrorInfo error
+        ErrorInfo error,
+        boolean coldStart,
+        Long initDurationMs
 ) {
 }

--- a/common/src/test/java/it/unimib/datai/nanofaas/common/model/CommonModelTest.java
+++ b/common/src/test/java/it/unimib/datai/nanofaas/common/model/CommonModelTest.java
@@ -70,13 +70,15 @@ class CommonModelTest {
 
     @Test
     void executionStatus_recordAccessors() {
-        ExecutionStatus s = new ExecutionStatus("ex-1", "COMPLETED", Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), "result", null);
+        ExecutionStatus s = new ExecutionStatus("ex-1", "COMPLETED", Instant.ofEpochMilli(100), Instant.ofEpochMilli(200), "result", null, true, 150L);
         assertEquals("ex-1", s.executionId());
         assertEquals("COMPLETED", s.status());
         assertEquals(Instant.ofEpochMilli(100), s.startedAt());
         assertEquals(Instant.ofEpochMilli(200), s.finishedAt());
         assertEquals("result", s.output());
         assertNull(s.error());
+        assertTrue(s.coldStart());
+        assertEquals(150L, s.initDurationMs());
     }
 
     // --- FunctionSpec ---

--- a/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/DispatchResult.java
+++ b/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/DispatchResult.java
@@ -1,0 +1,13 @@
+package it.unimib.datai.nanofaas.controlplane.dispatch;
+
+import it.unimib.datai.nanofaas.common.model.InvocationResult;
+
+public record DispatchResult(
+        InvocationResult result,
+        boolean coldStart,
+        Long initDurationMs
+) {
+    public static DispatchResult warm(InvocationResult result) {
+        return new DispatchResult(result, false, null);
+    }
+}

--- a/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/Dispatcher.java
+++ b/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/Dispatcher.java
@@ -1,10 +1,9 @@
 package it.unimib.datai.nanofaas.controlplane.dispatch;
 
-import it.unimib.datai.nanofaas.common.model.InvocationResult;
 import it.unimib.datai.nanofaas.controlplane.scheduler.InvocationTask;
 
 import java.util.concurrent.CompletableFuture;
 
 public interface Dispatcher {
-    CompletableFuture<InvocationResult> dispatch(InvocationTask task);
+    CompletableFuture<DispatchResult> dispatch(InvocationTask task);
 }

--- a/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/DispatcherRouter.java
+++ b/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/DispatcherRouter.java
@@ -1,6 +1,5 @@
 package it.unimib.datai.nanofaas.controlplane.dispatch;
 
-import it.unimib.datai.nanofaas.common.model.InvocationResult;
 import it.unimib.datai.nanofaas.controlplane.scheduler.InvocationTask;
 import org.springframework.stereotype.Component;
 
@@ -17,11 +16,11 @@ public class DispatcherRouter {
         this.poolDispatcher = poolDispatcher;
     }
 
-    public CompletableFuture<InvocationResult> dispatchLocal(InvocationTask task) {
+    public CompletableFuture<DispatchResult> dispatchLocal(InvocationTask task) {
         return localDispatcher.dispatch(task);
     }
 
-    public CompletableFuture<InvocationResult> dispatchPool(InvocationTask task) {
+    public CompletableFuture<DispatchResult> dispatchPool(InvocationTask task) {
         return poolDispatcher.dispatch(task);
     }
 }

--- a/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/LocalDispatcher.java
+++ b/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/dispatch/LocalDispatcher.java
@@ -9,7 +9,8 @@ import java.util.concurrent.CompletableFuture;
 @Component
 public class LocalDispatcher implements Dispatcher {
     @Override
-    public CompletableFuture<InvocationResult> dispatch(InvocationTask task) {
-        return CompletableFuture.completedFuture(InvocationResult.success(task.request().input()));
+    public CompletableFuture<DispatchResult> dispatch(InvocationTask task) {
+        return CompletableFuture.completedFuture(
+                DispatchResult.warm(InvocationResult.success(task.request().input())));
     }
 }

--- a/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/metrics/ColdStartTracker.java
+++ b/control-plane/src/main/java/it/unimib/datai/nanofaas/controlplane/metrics/ColdStartTracker.java
@@ -1,0 +1,41 @@
+package it.unimib.datai.nanofaas.controlplane.metrics;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks recent scale-up events to infer cold starts when the runtime
+ * does not report them via headers (e.g., old runtime images).
+ */
+@Component
+public class ColdStartTracker {
+    private static final long EXPIRY_MS = 30_000;
+
+    private final Map<String, ScaleUpEvent> recentScaleUps = new ConcurrentHashMap<>();
+
+    public void recordScaleUp(String functionName, int fromReplicas, int toReplicas) {
+        recentScaleUps.put(functionName, new ScaleUpEvent(fromReplicas, toReplicas, Instant.now()));
+    }
+
+    /**
+     * Returns true if the function recently scaled up from 0 replicas
+     * (within the expiry window), indicating a likely cold start.
+     */
+    public boolean isPotentialColdStart(String functionName) {
+        ScaleUpEvent event = recentScaleUps.get(functionName);
+        if (event == null) {
+            return false;
+        }
+        long ageMs = Instant.now().toEpochMilli() - event.timestamp().toEpochMilli();
+        if (ageMs > EXPIRY_MS) {
+            recentScaleUps.remove(functionName);
+            return false;
+        }
+        return event.fromReplicas() == 0;
+    }
+
+    private record ScaleUpEvent(int fromReplicas, int toReplicas, Instant timestamp) {}
+}

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherColdStartTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherColdStartTest.java
@@ -1,0 +1,71 @@
+package it.unimib.datai.nanofaas.controlplane.dispatch;
+
+import it.unimib.datai.nanofaas.common.model.ExecutionMode;
+import it.unimib.datai.nanofaas.common.model.FunctionSpec;
+import it.unimib.datai.nanofaas.common.model.InvocationRequest;
+import it.unimib.datai.nanofaas.controlplane.scheduler.InvocationTask;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PoolDispatcherColdStartTest {
+
+    @Test
+    void dispatch_extractsColdStartHeaders() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse()
+                .setBody("{\"message\":\"ok\"}")
+                .addHeader("Content-Type", "application/json")
+                .addHeader("X-Cold-Start", "true")
+                .addHeader("X-Init-Duration-Ms", "250"));
+        server.start();
+
+        InvocationTask task = createTask(server);
+        PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
+        DispatchResult dr = dispatcher.dispatch(task).get();
+
+        assertThat(dr.result().success()).isTrue();
+        assertThat(dr.coldStart()).isTrue();
+        assertThat(dr.initDurationMs()).isEqualTo(250L);
+
+        server.shutdown();
+    }
+
+    @Test
+    void dispatch_warmStart_noColdStartHeaders() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse()
+                .setBody("{\"message\":\"ok\"}")
+                .addHeader("Content-Type", "application/json"));
+        server.start();
+
+        InvocationTask task = createTask(server);
+        PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
+        DispatchResult dr = dispatcher.dispatch(task).get();
+
+        assertThat(dr.result().success()).isTrue();
+        assertThat(dr.coldStart()).isFalse();
+        assertThat(dr.initDurationMs()).isNull();
+
+        server.shutdown();
+    }
+
+    private InvocationTask createTask(MockWebServer server) {
+        String endpoint = server.url("/invoke").toString();
+        FunctionSpec spec = new FunctionSpec(
+                "test-fn", "image", null, Map.of(), null,
+                5000, 1, 10, 3, endpoint, ExecutionMode.POOL, null, null, null
+        );
+        return new InvocationTask(
+                "exec-cs", "test-fn", spec,
+                new InvocationRequest("payload", Map.of()),
+                null, null, Instant.now(), 1
+        );
+    }
+}

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherTest.java
@@ -3,7 +3,6 @@ package it.unimib.datai.nanofaas.controlplane.dispatch;
 import it.unimib.datai.nanofaas.common.model.ExecutionMode;
 import it.unimib.datai.nanofaas.common.model.FunctionSpec;
 import it.unimib.datai.nanofaas.common.model.InvocationRequest;
-import it.unimib.datai.nanofaas.common.model.InvocationResult;
 import it.unimib.datai.nanofaas.controlplane.scheduler.InvocationTask;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -14,6 +13,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,10 +57,11 @@ class PoolDispatcherTest {
         );
 
         PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
-        InvocationResult result = dispatcher.dispatch(task).get();
+        DispatchResult dr = dispatcher.dispatch(task).get();
 
-        assertTrue(result.success());
-        assertNotNull(result.output());
+        assertTrue(dr.result().success());
+        assertNotNull(dr.result().output());
+        assertFalse(dr.coldStart());
         assertEquals(1, server.getRequestCount());
         server.shutdown();
     }
@@ -104,10 +105,10 @@ class PoolDispatcherTest {
         );
 
         PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
-        InvocationResult result = dispatcher.dispatch(task).get();
+        DispatchResult dr = dispatcher.dispatch(task).get();
 
-        assertTrue(result.success());
-        assertEquals("plain-output", result.output());
+        assertTrue(dr.result().success());
+        assertEquals("plain-output", dr.result().output());
         server.shutdown();
     }
 }

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherTimeoutTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/dispatch/PoolDispatcherTimeoutTest.java
@@ -3,7 +3,6 @@ package it.unimib.datai.nanofaas.controlplane.dispatch;
 import it.unimib.datai.nanofaas.common.model.ExecutionMode;
 import it.unimib.datai.nanofaas.common.model.FunctionSpec;
 import it.unimib.datai.nanofaas.common.model.InvocationRequest;
-import it.unimib.datai.nanofaas.common.model.InvocationResult;
 import it.unimib.datai.nanofaas.controlplane.scheduler.InvocationTask;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -43,11 +42,11 @@ class PoolDispatcherTimeoutTest {
         );
 
         PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
-        InvocationResult result = dispatcher.dispatch(task).get();
+        DispatchResult dr = dispatcher.dispatch(task).get();
 
-        assertThat(result.success()).isFalse();
-        assertThat(result.error().code()).isEqualTo("POOL_TIMEOUT");
-        assertThat(result.error().message()).contains("200ms");
+        assertThat(dr.result().success()).isFalse();
+        assertThat(dr.result().error().code()).isEqualTo("POOL_TIMEOUT");
+        assertThat(dr.result().error().message()).contains("200ms");
 
         server.shutdown();
     }
@@ -66,10 +65,10 @@ class PoolDispatcherTimeoutTest {
         );
 
         PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
-        InvocationResult result = dispatcher.dispatch(task).get();
+        DispatchResult dr = dispatcher.dispatch(task).get();
 
-        assertThat(result.success()).isFalse();
-        assertThat(result.error().code()).isEqualTo("POOL_ENDPOINT_MISSING");
+        assertThat(dr.result().success()).isFalse();
+        assertThat(dr.result().error().code()).isEqualTo("POOL_ENDPOINT_MISSING");
     }
 
     @Test
@@ -92,10 +91,10 @@ class PoolDispatcherTimeoutTest {
         );
 
         PoolDispatcher dispatcher = new PoolDispatcher(WebClient.builder().build());
-        InvocationResult result = dispatcher.dispatch(task).get();
+        DispatchResult dr = dispatcher.dispatch(task).get();
 
-        assertThat(result.success()).isFalse();
-        assertThat(result.error().code()).isEqualTo("POOL_ERROR");
+        assertThat(dr.result().success()).isFalse();
+        assertThat(dr.result().error().code()).isEqualTo("POOL_ERROR");
 
         server.shutdown();
     }

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/execution/ExecutionRecordStateTransitionTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/execution/ExecutionRecordStateTransitionTest.java
@@ -104,6 +104,42 @@ class ExecutionRecordStateTransitionTest {
         assertThat(snapshot.finishedAt()).isNull();
     }
 
+    @Test
+    void markColdStart_setsFieldsInSnapshot() {
+        ExecutionRecord record = createRecord("exec-1");
+        record.markRunning();
+        record.markColdStart(350);
+
+        ExecutionRecord.Snapshot snapshot = record.snapshot();
+        assertThat(snapshot.coldStart()).isTrue();
+        assertThat(snapshot.initDurationMs()).isEqualTo(350L);
+    }
+
+    @Test
+    void markDispatchedAt_setsFieldInSnapshot() {
+        ExecutionRecord record = createRecord("exec-1");
+        record.markRunning();
+        record.markDispatchedAt();
+
+        ExecutionRecord.Snapshot snapshot = record.snapshot();
+        assertThat(snapshot.dispatchedAt()).isNotNull();
+    }
+
+    @Test
+    void resetForRetry_clearsColdStartFields() {
+        ExecutionRecord record = createRecord("exec-1");
+        record.markRunning();
+        record.markColdStart(200);
+        record.markDispatchedAt();
+
+        record.resetForRetry(createTask("exec-1"));
+
+        ExecutionRecord.Snapshot snapshot = record.snapshot();
+        assertThat(snapshot.coldStart()).isFalse();
+        assertThat(snapshot.initDurationMs()).isNull();
+        assertThat(snapshot.dispatchedAt()).isNull();
+    }
+
     private ExecutionRecord createRecord(String executionId) {
         return new ExecutionRecord(executionId, createTask(executionId));
     }

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/metrics/ColdStartTrackerTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/metrics/ColdStartTrackerTest.java
@@ -1,0 +1,36 @@
+package it.unimib.datai.nanofaas.controlplane.metrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ColdStartTrackerTest {
+
+    @Test
+    void isPotentialColdStart_returnsFalse_whenNoScaleUpRecorded() {
+        ColdStartTracker tracker = new ColdStartTracker();
+        assertThat(tracker.isPotentialColdStart("myFunc")).isFalse();
+    }
+
+    @Test
+    void isPotentialColdStart_returnsTrue_afterScaleUpFromZero() {
+        ColdStartTracker tracker = new ColdStartTracker();
+        tracker.recordScaleUp("myFunc", 0, 1);
+        assertThat(tracker.isPotentialColdStart("myFunc")).isTrue();
+    }
+
+    @Test
+    void isPotentialColdStart_returnsFalse_afterScaleUpFromNonZero() {
+        ColdStartTracker tracker = new ColdStartTracker();
+        tracker.recordScaleUp("myFunc", 1, 3);
+        assertThat(tracker.isPotentialColdStart("myFunc")).isFalse();
+    }
+
+    @Test
+    void isPotentialColdStart_differentFunctions_areIndependent() {
+        ColdStartTracker tracker = new ColdStartTracker();
+        tracker.recordScaleUp("funcA", 0, 1);
+        assertThat(tracker.isPotentialColdStart("funcA")).isTrue();
+        assertThat(tracker.isPotentialColdStart("funcB")).isFalse();
+    }
+}

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/scaling/InternalScalerTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/scaling/InternalScalerTest.java
@@ -2,6 +2,7 @@ package it.unimib.datai.nanofaas.controlplane.scaling;
 
 import it.unimib.datai.nanofaas.common.model.*;
 import it.unimib.datai.nanofaas.controlplane.dispatch.KubernetesResourceManager;
+import it.unimib.datai.nanofaas.controlplane.metrics.ColdStartTracker;
 import it.unimib.datai.nanofaas.controlplane.registry.FunctionRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,9 +32,11 @@ class InternalScalerTest {
 
     private static final ScalingProperties PROPS = new ScalingProperties(5000L, 1, 10);
 
+    private final ColdStartTracker coldStartTracker = new ColdStartTracker();
+
     @BeforeEach
     void setUp() {
-        scaler = new InternalScaler(registry, metricsReader, resourceManager, PROPS);
+        scaler = new InternalScaler(registry, metricsReader, resourceManager, PROPS, coldStartTracker);
     }
 
     private FunctionSpec functionSpec(String name, ExecutionMode mode, ScalingConfig scaling) {
@@ -136,7 +139,7 @@ class InternalScalerTest {
 
     @Test
     void doesNotStartWithoutResourceManager() {
-        InternalScaler noK8sScaler = new InternalScaler(registry, metricsReader, null, PROPS);
+        InternalScaler noK8sScaler = new InternalScaler(registry, metricsReader, null, PROPS, coldStartTracker);
         noK8sScaler.start();
         assertFalse(noK8sScaler.isRunning());
     }

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/InvocationServiceRetryQueueFullTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/InvocationServiceRetryQueueFullTest.java
@@ -62,9 +62,11 @@ class InvocationServiceRetryQueueFullTest {
 
         when(functionService.get("testFunc")).thenReturn(Optional.of(testSpec));
         when(syncQueueService.enabled()).thenReturn(false);
-        when(metrics.latency(anyString())).thenReturn(
-                io.micrometer.core.instrument.Timer.builder("test")
-                        .register(new io.micrometer.core.instrument.simple.SimpleMeterRegistry()));
+        io.micrometer.core.instrument.simple.SimpleMeterRegistry simpleMeterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+        when(metrics.latency(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-latency").register(simpleMeterRegistry));
+        when(metrics.queueWait(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-queue-wait").register(simpleMeterRegistry));
+        when(metrics.e2eLatency(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-e2e").register(simpleMeterRegistry));
+        when(metrics.initDuration(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-init").register(simpleMeterRegistry));
     }
 
     @Test

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/InvocationServiceRetryTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/InvocationServiceRetryTest.java
@@ -95,7 +95,11 @@ class InvocationServiceRetryTest {
         when(functionService.get("testFunc")).thenReturn(Optional.of(testSpec));
         when(queueManager.enqueue(any())).thenReturn(true);
         when(syncQueueService.enabled()).thenReturn(false);
-        when(metrics.latency(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test").register(new io.micrometer.core.instrument.simple.SimpleMeterRegistry()));
+        io.micrometer.core.instrument.simple.SimpleMeterRegistry simpleMeterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+        when(metrics.latency(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-latency").register(simpleMeterRegistry));
+        when(metrics.queueWait(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-queue-wait").register(simpleMeterRegistry));
+        when(metrics.e2eLatency(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-e2e").register(simpleMeterRegistry));
+        when(metrics.initDuration(anyString())).thenReturn(io.micrometer.core.instrument.Timer.builder("test-init").register(simpleMeterRegistry));
     }
 
     @Test

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/MetricsTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/service/MetricsTest.java
@@ -1,0 +1,71 @@
+package it.unimib.datai.nanofaas.controlplane.service;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetricsTest {
+    private SimpleMeterRegistry registry;
+    private Metrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        metrics = new Metrics(registry);
+    }
+
+    @Test
+    void coldStart_incrementsCounter() {
+        metrics.coldStart("echo");
+        metrics.coldStart("echo");
+
+        Counter counter = registry.find("function_cold_start_total")
+                .tag("function", "echo").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(2.0);
+    }
+
+    @Test
+    void warmStart_incrementsCounter() {
+        metrics.warmStart("echo");
+
+        Counter counter = registry.find("function_warm_start_total")
+                .tag("function", "echo").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void initDuration_registersTimer() {
+        Timer timer = metrics.initDuration("echo");
+        assertThat(timer).isNotNull();
+
+        Timer found = registry.find("function_init_duration_ms")
+                .tag("function", "echo").timer();
+        assertThat(found).isSameAs(timer);
+    }
+
+    @Test
+    void queueWait_registersTimer() {
+        Timer timer = metrics.queueWait("echo");
+        assertThat(timer).isNotNull();
+
+        Timer found = registry.find("function_queue_wait_ms")
+                .tag("function", "echo").timer();
+        assertThat(found).isSameAs(timer);
+    }
+
+    @Test
+    void e2eLatency_registersTimer() {
+        Timer timer = metrics.e2eLatency("echo");
+        assertThat(timer).isNotNull();
+
+        Timer found = registry.find("function_e2e_latency_ms")
+                .tag("function", "echo").timer();
+        assertThat(found).isSameAs(timer);
+    }
+}

--- a/scripts/e2e-cold-start-metrics.sh
+++ b/scripts/e2e-cold-start-metrics.sh
@@ -1,0 +1,563 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# E2E test: Cold Start Metrics Verification
+# Deploys to k3s, invokes a function, verifies cold/warm start Prometheus metrics.
+
+VM_NAME=${VM_NAME:-nanofaas-cold-metrics-e2e-$(date +%s)}
+CPUS=${CPUS:-4}
+MEMORY=${MEMORY:-8G}
+DISK=${DISK:-30G}
+NAMESPACE=${NAMESPACE:-nanofaas-e2e}
+LOCAL_REGISTRY=${LOCAL_REGISTRY:-localhost:5000}
+CONTROL_IMAGE=${CONTROL_PLANE_IMAGE:-${LOCAL_REGISTRY}/nanofaas/control-plane:e2e}
+RUNTIME_IMAGE=${FUNCTION_RUNTIME_IMAGE:-${LOCAL_REGISTRY}/nanofaas/function-runtime:e2e}
+KEEP_VM=${KEEP_VM:-false}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+source "${SCRIPT_DIR}/lib/e2e-k3s-common.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[cold-start-e2e]${NC} $*"; }
+warn() { echo -e "${YELLOW}[cold-start-e2e]${NC} $*"; }
+error() { echo -e "${RED}[cold-start-e2e]${NC} $*" >&2; }
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+cleanup() {
+    local exit_code=$?
+    if [[ "${KEEP_VM}" == "true" ]]; then
+        warn "KEEP_VM=true, VM '${VM_NAME}' preserved for debugging"
+        warn "SSH: multipass shell ${VM_NAME}"
+        warn "Delete: multipass delete ${VM_NAME} && multipass purge"
+        return
+    fi
+    log "Cleaning up VM ${VM_NAME}..."
+    multipass delete "${VM_NAME}" 2>/dev/null || true
+    multipass purge 2>/dev/null || true
+    exit $exit_code
+}
+
+trap cleanup EXIT
+
+vm_exec() {
+    multipass exec "${VM_NAME}" -- bash -lc "export KUBECONFIG=/home/ubuntu/.kube/config; $*"
+}
+
+# --- Setup (reused pattern from e2e-k3s-curl.sh) ---
+
+check_prerequisites() {
+    e2e_require_multipass
+    log "Prerequisites check passed"
+}
+
+create_vm() {
+    log "Creating VM ${VM_NAME} (cpus=${CPUS}, memory=${MEMORY}, disk=${DISK})..."
+    multipass launch --name "${VM_NAME}" --cpus "${CPUS}" --memory "${MEMORY}" --disk "${DISK}"
+    log "VM created successfully"
+}
+
+install_dependencies() {
+    log "Installing dependencies in VM..."
+    vm_exec "sudo apt-get update -y"
+    vm_exec "sudo apt-get install -y curl ca-certificates tar unzip openjdk-21-jdk"
+    vm_exec "if ! command -v docker >/dev/null 2>&1; then
+        curl -fsSL https://get.docker.com | sudo sh
+        sudo usermod -aG docker ubuntu
+    fi"
+    log "Dependencies installed"
+}
+
+install_k3s() {
+    e2e_install_k3s
+}
+
+sync_project() {
+    log "Syncing project to VM..."
+    vm_exec "rm -rf /home/ubuntu/nanofaas"
+    multipass transfer --recursive "${PROJECT_ROOT}" "${VM_NAME}:/home/ubuntu/nanofaas"
+    log "Project synced"
+}
+
+build_jars() {
+    log "Building JARs in VM..."
+    vm_exec "cd /home/ubuntu/nanofaas && ./gradlew :control-plane:bootJar :function-runtime:bootJar --no-daemon -q"
+    log "JARs built"
+}
+
+build_images() {
+    log "Building Docker images in VM..."
+    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${CONTROL_IMAGE} -f control-plane/Dockerfile control-plane/"
+    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${RUNTIME_IMAGE} -f function-runtime/Dockerfile function-runtime/"
+    log "Docker images built"
+}
+
+push_images_to_registry() {
+    e2e_push_images_to_registry "${CONTROL_IMAGE}" "${RUNTIME_IMAGE}"
+}
+
+create_namespace() {
+    log "Creating namespace ${NAMESPACE}..."
+    vm_exec "kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -"
+    log "Namespace created"
+}
+
+deploy_control_plane() {
+    log "Deploying control-plane..."
+
+    vm_exec "cat <<'EOF' | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: control-plane
+  namespace: ${NAMESPACE}
+  labels:
+    app: control-plane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: control-plane
+  template:
+    metadata:
+      labels:
+        app: control-plane
+    spec:
+      containers:
+      - name: control-plane
+        image: ${CONTROL_IMAGE}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: api
+        - containerPort: 8081
+          name: management
+        env:
+        - name: POD_NAMESPACE
+          value: \"${NAMESPACE}\"
+        - name: SYNC_QUEUE_ENABLED
+          value: \"false\"
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: control-plane
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: control-plane
+  ports:
+  - name: api
+    port: 8080
+    targetPort: 8080
+  - name: management
+    port: 8081
+    targetPort: 8081
+EOF"
+
+    log "Control-plane deployment created"
+}
+
+deploy_function_runtime() {
+    log "Deploying function-runtime..."
+
+    vm_exec "cat <<'EOF' | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: function-runtime
+  namespace: ${NAMESPACE}
+  labels:
+    app: function-runtime
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: function-runtime
+  template:
+    metadata:
+      labels:
+        app: function-runtime
+    spec:
+      containers:
+      - name: function-runtime
+        image: ${RUNTIME_IMAGE}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: function-runtime
+  namespace: ${NAMESPACE}
+spec:
+  selector:
+    app: function-runtime
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+EOF"
+
+    log "Function-runtime deployment created"
+}
+
+wait_for_deployment() {
+    local name=$1
+    local timeout=${2:-180}
+    log "Waiting for deployment ${name} to be ready (timeout: ${timeout}s)..."
+    vm_exec "kubectl rollout status deployment/${name} -n ${NAMESPACE} --timeout=${timeout}s"
+    log "Deployment ${name} is ready"
+}
+
+verify_pods_running() {
+    log "Verifying all pods are running..."
+
+    local cp_status
+    cp_status=$(vm_exec "kubectl get pods -n ${NAMESPACE} -l app=control-plane -o jsonpath='{.items[0].status.phase}'")
+    if [[ "${cp_status}" != "Running" ]]; then
+        error "control-plane pod is not Running (status: ${cp_status})"
+        vm_exec "kubectl describe pod -n ${NAMESPACE} -l app=control-plane"
+        exit 1
+    fi
+    log "  control-plane: Running"
+
+    local fr_status
+    fr_status=$(vm_exec "kubectl get pods -n ${NAMESPACE} -l app=function-runtime -o jsonpath='{.items[0].status.phase}'")
+    if [[ "${fr_status}" != "Running" ]]; then
+        error "function-runtime pod is not Running (status: ${fr_status})"
+        vm_exec "kubectl describe pod -n ${NAMESPACE} -l app=function-runtime"
+        exit 1
+    fi
+    log "  function-runtime: Running"
+
+    log "All pods running"
+}
+
+dump_pod_logs() {
+    warn "--- control-plane logs (last 50 lines) ---"
+    vm_exec "kubectl logs -n ${NAMESPACE} -l app=control-plane --tail=50" 2>/dev/null || true
+    warn "--- function-runtime logs (last 50 lines) ---"
+    vm_exec "kubectl logs -n ${NAMESPACE} -l app=function-runtime --tail=50" 2>/dev/null || true
+}
+
+# --- Test-specific functions ---
+
+register_function() {
+    log "Registering echo-test function in POOL mode..."
+
+    vm_exec "kubectl run curl-register --rm -i --restart=Never --image=curlimages/curl:latest -n ${NAMESPACE} -- \
+        curl -sf -X POST http://control-plane:8080/v1/functions \
+        -H 'Content-Type: application/json' \
+        -d '{
+            \"name\": \"echo-test\",
+            \"image\": \"${RUNTIME_IMAGE}\",
+            \"timeoutMs\": 30000,
+            \"concurrency\": 2,
+            \"queueSize\": 20,
+            \"maxRetries\": 3,
+            \"executionMode\": \"POOL\",
+            \"endpointUrl\": \"http://function-runtime:8080/invoke\"
+        }'"
+
+    log "Function registered"
+
+    # Allow scheduler to pick up the new function
+    sleep 2
+}
+
+invoke_sync() {
+    local label=$1
+    log "Sync invoke (${label})..."
+
+    # Invoke and capture response. kubectl run --rm -i mixes pod deletion message
+    # into stdout, so we grep for the JSON body instead of parsing HTTP codes.
+    local response
+    response=$(vm_exec "kubectl run curl-invoke-${label} --rm -i --restart=Never --image=curlimages/curl:latest -n ${NAMESPACE} -- \
+        curl -s --max-time 35 -X POST http://control-plane:8080/v1/functions/echo-test:invoke \
+        -H 'Content-Type: application/json' \
+        -d '{\"input\": {\"message\": \"${label}\"}}'")
+
+    # Extract JSON body (line containing executionId)
+    local body
+    body=$(echo "${response}" | grep '"executionId"' | head -1)
+
+    if [[ -z "${body}" ]]; then
+        error "  ${label}: No valid JSON response — raw output: ${response}"
+        return 1
+    fi
+
+    # Check for error status
+    if echo "${body}" | grep -q '"status":"error"'; then
+        error "  ${label}: Error response — ${body}"
+        return 1
+    fi
+
+    # Extract executionId
+    local exec_id
+    exec_id=$(echo "${body}" | sed -n 's/.*"executionId":"\([^"]*\)".*/\1/p')
+
+    if [[ -z "${exec_id}" ]]; then
+        warn "  Could not extract executionId from response: ${body}"
+        return
+    fi
+
+    # Query execution status to get cold start details
+    local status_response
+    status_response=$(vm_exec "kubectl run curl-status-${label} --rm -i --restart=Never --image=curlimages/curl:latest -n ${NAMESPACE} -- \
+        curl -s --max-time 10 http://control-plane:8080/v1/executions/${exec_id}" | grep '"executionId"' | head -1)
+
+    local is_cold
+    is_cold=$(echo "${status_response}" | sed -n 's/.*"coldStart":\([a-z]*\).*/\1/p')
+    local init_ms
+    init_ms=$(echo "${status_response}" | sed -n 's/.*"initDurationMs":\([0-9]*\).*/\1/p')
+
+    if [[ "${is_cold}" == "true" ]]; then
+        log "  ${label}: COLD START (initDurationMs=${init_ms:-N/A}ms) [executionId=${exec_id}]"
+    else
+        log "  ${label}: WARM START [executionId=${exec_id}]"
+    fi
+}
+
+assert_metric_gte() {
+    local metrics=$1
+    local metric_name=$2
+    local min_value=$3
+    local description=$4
+
+    local value
+    value=$(echo "${metrics}" | grep "${metric_name}" | grep 'function="echo-test"' | grep -v '^#' | head -1 | awk '{print $NF}')
+
+    if [[ -z "${value}" ]]; then
+        error "FAIL: ${description} — metric '${metric_name}' not found"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    # Compare as floats: value >= min_value
+    if awk "BEGIN {exit !(${value} >= ${min_value})}"; then
+        log "  PASS: ${description} (${metric_name} = ${value}, expected >= ${min_value})"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "FAIL: ${description} (${metric_name} = ${value}, expected >= ${min_value})"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_metric_exists() {
+    local metrics=$1
+    local metric_name=$2
+    local description=$3
+
+    if echo "${metrics}" | grep -q "${metric_name}"; then
+        log "  PASS: ${description} (${metric_name} present)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "FAIL: ${description} (${metric_name} not found)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_metric_gt() {
+    local metrics=$1
+    local metric_name=$2
+    local min_exclusive=$3
+    local description=$4
+
+    local value
+    value=$(echo "${metrics}" | grep "${metric_name}" | grep 'function="echo-test"' | grep -v '^#' | head -1 | awk '{print $NF}')
+
+    if [[ -z "${value}" ]]; then
+        error "FAIL: ${description} — metric '${metric_name}' not found"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    if awk "BEGIN {exit !(${value} > ${min_exclusive})}"; then
+        log "  PASS: ${description} (${metric_name} = ${value}, expected > ${min_exclusive})"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "FAIL: ${description} (${metric_name} = ${value}, expected > ${min_exclusive})"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+verify_cold_start_metrics() {
+    log "Scraping Prometheus metrics from control-plane management port..."
+
+    local pod_name
+    pod_name=$(vm_exec "kubectl get pods -n ${NAMESPACE} -l app=control-plane -o jsonpath='{.items[0].metadata.name}'")
+
+    local metrics
+    metrics=$(vm_exec "kubectl exec -n ${NAMESPACE} ${pod_name} -- curl -sf http://localhost:8081/actuator/prometheus")
+
+    log "Asserting cold start metrics..."
+
+    # Cold start counter: at least 1 (the first invocation)
+    assert_metric_gte "${metrics}" "function_cold_start_total" 1 \
+        "Cold start counter >= 1" || true
+
+    # Warm start counter: at least 1 (invocations 2-5)
+    assert_metric_gte "${metrics}" "function_warm_start_total" 1 \
+        "Warm start counter >= 1" || true
+
+    # Init duration timer count: at least 1 recording
+    # Micrometer Timer "function_init_duration_ms" → Prometheus "function_init_duration_ms_seconds_count"
+    assert_metric_gte "${metrics}" "function_init_duration_ms_seconds_count" 1 \
+        "Init duration timer count >= 1" || true
+
+    # Init duration timer sum: should be > 0
+    assert_metric_gt "${metrics}" "function_init_duration_ms_seconds_sum" 0 \
+        "Init duration timer sum > 0" || true
+
+    # Queue wait timer count: at least 1
+    assert_metric_gte "${metrics}" "function_queue_wait_ms_seconds_count" 1 \
+        "Queue wait timer count >= 1" || true
+
+    # E2E latency timer count: at least 1
+    assert_metric_gte "${metrics}" "function_e2e_latency_ms_seconds_count" 1 \
+        "E2E latency timer count >= 1" || true
+
+    # Backward compat: function_latency_ms timer exists
+    assert_metric_exists "${metrics}" "function_latency_ms_seconds_count" \
+        "Legacy latency timer exists" || true
+
+    # Print a summary of timing values for visibility
+    log ""
+    log "Timing summary from Prometheus metrics:"
+    local init_sum init_count queue_sum queue_count e2e_sum e2e_count
+
+    init_sum=$(echo "${metrics}" | grep 'function_init_duration_ms_seconds_sum' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    init_count=$(echo "${metrics}" | grep 'function_init_duration_ms_seconds_count' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    if [[ -n "${init_sum}" && -n "${init_count}" ]]; then
+        log "  Init duration:  sum=${init_sum}s  count=${init_count}"
+    fi
+
+    queue_sum=$(echo "${metrics}" | grep 'function_queue_wait_ms_seconds_sum' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    queue_count=$(echo "${metrics}" | grep 'function_queue_wait_ms_seconds_count' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    if [[ -n "${queue_sum}" && -n "${queue_count}" ]]; then
+        log "  Queue wait:     sum=${queue_sum}s  count=${queue_count}"
+    fi
+
+    e2e_sum=$(echo "${metrics}" | grep 'function_e2e_latency_ms_seconds_sum' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    e2e_count=$(echo "${metrics}" | grep 'function_e2e_latency_ms_seconds_count' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    if [[ -n "${e2e_sum}" && -n "${e2e_count}" ]]; then
+        log "  E2E latency:    sum=${e2e_sum}s  count=${e2e_count}"
+    fi
+
+    local cold_total warm_total
+    cold_total=$(echo "${metrics}" | grep 'function_cold_start_total' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    warm_total=$(echo "${metrics}" | grep 'function_warm_start_total' | grep 'function="echo-test"' | grep -v '^#' | awk '{print $NF}')
+    log "  Cold starts: ${cold_total:-0}  Warm starts: ${warm_total:-0}"
+}
+
+print_summary() {
+    log ""
+    log "=========================================="
+    log "  COLD START METRICS E2E TEST COMPLETE"
+    log "=========================================="
+    log ""
+    log "  VM: ${VM_NAME}"
+    log "  Namespace: ${NAMESPACE}"
+    log ""
+    log "  Assertions passed: ${TESTS_PASSED}"
+    log "  Assertions failed: ${TESTS_FAILED}"
+    log ""
+
+    if [[ "${TESTS_FAILED}" -gt 0 ]]; then
+        error "SOME ASSERTIONS FAILED"
+        exit 1
+    fi
+
+    log "ALL ASSERTIONS PASSED"
+}
+
+main() {
+    log "Starting Cold Start Metrics E2E test..."
+    log "Configuration:"
+    log "  VM_NAME=${VM_NAME}"
+    log "  CPUS=${CPUS}, MEMORY=${MEMORY}, DISK=${DISK}"
+    log "  NAMESPACE=${NAMESPACE}"
+    log "  LOCAL_REGISTRY=${LOCAL_REGISTRY}"
+    log "  KEEP_VM=${KEEP_VM}"
+    log ""
+
+    # Phase 1: Setup
+    check_prerequisites
+    create_vm
+    install_dependencies
+    install_k3s
+    e2e_setup_local_registry "${LOCAL_REGISTRY}"
+
+    # Phase 2: Build
+    sync_project
+    build_jars
+    build_images
+    push_images_to_registry
+
+    # Phase 3: Deploy
+    create_namespace
+    deploy_control_plane
+    deploy_function_runtime
+
+    # Phase 4: Verify deployment
+    wait_for_deployment "control-plane" 180
+    wait_for_deployment "function-runtime" 120
+    verify_pods_running
+
+    # Phase 5: Invoke — 1 cold start + 4 warm starts
+    register_function
+
+    log "Invoking function 5 times (1 cold + 4 warm)..."
+    invoke_sync "cold-1" || { error "First invoke failed — check control-plane and function-runtime logs"; dump_pod_logs; exit 1; }
+    sleep 1
+    invoke_sync "warm-2" || true
+    invoke_sync "warm-3" || true
+    invoke_sync "warm-4" || true
+    invoke_sync "warm-5" || true
+
+    # Allow metrics to flush
+    sleep 3
+
+    # Phase 6: Assert metrics
+    verify_cold_start_metrics
+
+    # Done
+    print_summary
+}
+
+main "$@"


### PR DESCRIPTION
Implement cold/warm start detection across the stack: function-sdk-java
reports X-Cold-Start/X-Init-Duration-Ms headers, PoolDispatcher extracts
them into DispatchResult, and InvocationService records Prometheus metrics
(cold_start_total, warm_start_total, init_duration, queue_wait, e2e_latency).
Add e2e-cold-start-metrics.sh to verify metrics end-to-end on k3s.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
