### PR TITLE
Fix async callbacks, Prometheus diagnostics, and enable autoscaling

### DIFF
--- a/.github/workflows/gitops.yml
+++ b/.github/workflows/gitops.yml
@@ -113,21 +113,20 @@ jobs:
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-word-stats --all-tags
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-json-transform --all-tags
 
-      - name: Build Java Lite distributions
-        run: ./gradlew :examples:java:word-stats-lite:installDist :examples:java:json-transform-lite:installDist
-
-      - name: Build and push Java Lite Word Stats
+      - name: Build and push Java Lite Word Stats (native)
         uses: docker/build-push-action@v5
         with:
-          context: ./examples/java/word-stats-lite
+          context: .
+          file: examples/java/word-stats-lite/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-lite-word-stats:${{ github.ref_name }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-lite-word-stats:latest
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
-      - name: Build and push Java Lite JSON Transform
+      - name: Build and push Java Lite JSON Transform (native)
         uses: docker/build-push-action@v5
         with:
-          context: ./examples/java/json-transform-lite
+          context: .
+          file: examples/java/json-transform-lite/Dockerfile
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-lite-json-transform:${{ github.ref_name }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/java-lite-json-transform:latest
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/e2e/SdkExamplesE2eTest.java
+++ b/control-plane/src/test/java/it/unimib/datai/nanofaas/controlplane/e2e/SdkExamplesE2eTest.java
@@ -64,33 +64,27 @@ class SdkExamplesE2eTest {
             .withNetworkAliases("json-transform")
             .waitingFor(Wait.forHttp("/actuator/health").forPort(8080).withStartupTimeout(Duration.ofSeconds(60)));
 
-    // word-stats-lite function container (Lite SDK)
-    private static final java.nio.file.Path WORD_STATS_LITE_DIST =
-            E2eTestSupport.PROJECT_ROOT.resolve("examples/java/word-stats-lite/build/install/word-stats-lite");
+    // word-stats-lite function container (Lite SDK, native multi-stage build)
     private static final GenericContainer<?> wordStatsLite = new GenericContainer<>(
             new ImageFromDockerfile()
-                    .withFileFromPath("Dockerfile",
-                            E2eTestSupport.PROJECT_ROOT.resolve("examples/java/word-stats-lite/Dockerfile"))
-                    .withFileFromPath("build/install/word-stats-lite", WORD_STATS_LITE_DIST)
+                    .withFileFromPath(".", E2eTestSupport.PROJECT_ROOT)
+                    .withDockerfilePath("examples/java/word-stats-lite/Dockerfile")
     )
             .withExposedPorts(8080)
             .withNetwork(network)
             .withNetworkAliases("word-stats-lite")
-            .waitingFor(Wait.forHttp("/health").forPort(8080).withStartupTimeout(Duration.ofSeconds(60)));
+            .waitingFor(Wait.forHttp("/health").forPort(8080).withStartupTimeout(Duration.ofSeconds(300)));
 
-    // json-transform-lite function container (Lite SDK)
-    private static final java.nio.file.Path JSON_TRANSFORM_LITE_DIST =
-            E2eTestSupport.PROJECT_ROOT.resolve("examples/java/json-transform-lite/build/install/json-transform-lite");
+    // json-transform-lite function container (Lite SDK, native multi-stage build)
     private static final GenericContainer<?> jsonTransformLite = new GenericContainer<>(
             new ImageFromDockerfile()
-                    .withFileFromPath("Dockerfile",
-                            E2eTestSupport.PROJECT_ROOT.resolve("examples/java/json-transform-lite/Dockerfile"))
-                    .withFileFromPath("build/install/json-transform-lite", JSON_TRANSFORM_LITE_DIST)
+                    .withFileFromPath(".", E2eTestSupport.PROJECT_ROOT)
+                    .withDockerfilePath("examples/java/json-transform-lite/Dockerfile")
     )
             .withExposedPorts(8080)
             .withNetwork(network)
             .withNetworkAliases("json-transform-lite")
-            .waitingFor(Wait.forHttp("/health").forPort(8080).withStartupTimeout(Duration.ofSeconds(60)));
+            .waitingFor(Wait.forHttp("/health").forPort(8080).withStartupTimeout(Duration.ofSeconds(300)));
 
     // control plane
     private static final GenericContainer<?> controlPlane = new GenericContainer<>(

--- a/examples/java/json-transform-lite/Dockerfile
+++ b/examples/java/json-transform-lite/Dockerfile
@@ -1,7 +1,32 @@
-# JVM-only local development Dockerfile for lite SDK.
-# Production native images are built via GraalVM native-image.
-FROM eclipse-temurin:21-jre
+# Multi-stage native build for json-transform-lite.
+# Stage 1: GraalVM native-image compilation via Gradle.
+# Stage 2: Minimal runtime image with the static binary.
+
+FROM ghcr.io/graalvm/native-image-community:21 AS builder
+
+# Install findutils (provides xargs, required by gradlew)
+RUN microdnf install -y findutils && microdnf clean all
+
+WORKDIR /build
+
+# Copy Gradle wrapper and root build config
+COPY gradlew build.gradle gradle.properties ./
+COPY gradle/ gradle/
+
+# Use a minimal settings.gradle with only required modules
+COPY examples/java/json-transform-lite/settings.gradle.docker settings.gradle
+
+# Copy only required modules
+COPY common/ common/
+COPY function-sdk-java-lite/ function-sdk-java-lite/
+COPY examples/java/json-transform-lite/ examples/java/json-transform-lite/
+
+# Build the native binary
+RUN ./gradlew :examples:java:json-transform-lite:nativeCompile --no-daemon
+
+# Stage 2: minimal runtime
+FROM debian:bookworm-slim
 WORKDIR /app
-COPY build/install/json-transform-lite/ /app/
+COPY --from=builder /build/examples/java/json-transform-lite/build/native/nativeCompile/json-transform-lite /app/json-transform-lite
 EXPOSE 8080
-ENTRYPOINT ["/app/bin/json-transform-lite"]
+ENTRYPOINT ["/app/json-transform-lite"]

--- a/examples/java/json-transform-lite/settings.gradle.docker
+++ b/examples/java/json-transform-lite/settings.gradle.docker
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
+rootProject.name = 'nanofaas'
+
+include('common')
+include('function-sdk-java-lite')
+include('examples:java:json-transform-lite')

--- a/examples/java/word-stats-lite/Dockerfile
+++ b/examples/java/word-stats-lite/Dockerfile
@@ -1,7 +1,32 @@
-# JVM-only local development Dockerfile for lite SDK.
-# Production native images are built via GraalVM native-image.
-FROM eclipse-temurin:21-jre
+# Multi-stage native build for word-stats-lite.
+# Stage 1: GraalVM native-image compilation via Gradle.
+# Stage 2: Minimal runtime image with the static binary.
+
+FROM ghcr.io/graalvm/native-image-community:21 AS builder
+
+# Install findutils (provides xargs, required by gradlew)
+RUN microdnf install -y findutils && microdnf clean all
+
+WORKDIR /build
+
+# Copy Gradle wrapper and root build config
+COPY gradlew build.gradle gradle.properties ./
+COPY gradle/ gradle/
+
+# Use a minimal settings.gradle with only required modules
+COPY examples/java/word-stats-lite/settings.gradle.docker settings.gradle
+
+# Copy only required modules
+COPY common/ common/
+COPY function-sdk-java-lite/ function-sdk-java-lite/
+COPY examples/java/word-stats-lite/ examples/java/word-stats-lite/
+
+# Build the native binary
+RUN ./gradlew :examples:java:word-stats-lite:nativeCompile --no-daemon
+
+# Stage 2: minimal runtime
+FROM debian:bookworm-slim
 WORKDIR /app
-COPY build/install/word-stats-lite/ /app/
+COPY --from=builder /build/examples/java/word-stats-lite/build/native/nativeCompile/word-stats-lite /app/word-stats-lite
 EXPOSE 8080
-ENTRYPOINT ["/app/bin/word-stats-lite"]
+ENTRYPOINT ["/app/word-stats-lite"]

--- a/examples/java/word-stats-lite/settings.gradle.docker
+++ b/examples/java/word-stats-lite/settings.gradle.docker
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
+rootProject.name = 'nanofaas'
+
+include('common')
+include('function-sdk-java-lite')
+include('examples:java:word-stats-lite')

--- a/function-sdk-java/src/test/java/it/unimib/datai/nanofaas/sdk/runtime/InvokeControllerTest.java
+++ b/function-sdk-java/src/test/java/it/unimib/datai/nanofaas/sdk/runtime/InvokeControllerTest.java
@@ -41,7 +41,7 @@ class InvokeControllerTest {
 
         assertEquals(200, response.getStatusCode().value());
         assertEquals(Map.of("result", "hello"), response.getBody());
-        verify(callbackClient).sendResult(eq("env-exec-id"), any(InvocationResult.class), eq("trace-1"));
+        verify(callbackClient, timeout(2000)).sendResult(eq("env-exec-id"), any(InvocationResult.class), eq("trace-1"));
     }
 
     @Test
@@ -52,7 +52,7 @@ class InvokeControllerTest {
         InvocationRequest request = new InvocationRequest("input", null);
         controller.invoke(request, "header-exec-id", null);
 
-        verify(callbackClient).sendResult(eq("header-exec-id"), any(), isNull());
+        verify(callbackClient, timeout(2000)).sendResult(eq("header-exec-id"), any(), isNull());
     }
 
     @Test
@@ -66,7 +66,7 @@ class InvokeControllerTest {
         @SuppressWarnings("unchecked")
         Map<String, String> body = (Map<String, String>) response.getBody();
         assertEquals("boom", body.get("error"));
-        verify(callbackClient).sendResult(eq("env-exec-id"), argThat(r -> !r.success()), eq("t-1"));
+        verify(callbackClient, timeout(2000)).sendResult(eq("env-exec-id"), argThat(r -> !r.success()), eq("t-1"));
     }
 
     @Test

--- a/helm/nanofaas/values.yaml
+++ b/helm/nanofaas/values.yaml
@@ -83,6 +83,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: json-transform-java
       image: ghcr.io/miciav/nanofaas/java-json-transform:v0.10.0
       timeoutMs: 10000
@@ -90,6 +97,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: word-stats-python
       image: ghcr.io/miciav/nanofaas/python-word-stats:v0.10.0
       timeoutMs: 10000
@@ -97,6 +111,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: json-transform-python
       image: ghcr.io/miciav/nanofaas/python-json-transform:v0.10.0
       timeoutMs: 10000
@@ -104,6 +125,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: word-stats-exec
       image: ghcr.io/miciav/nanofaas/bash-word-stats:v0.10.0
       timeoutMs: 10000
@@ -111,6 +139,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: json-transform-exec
       image: ghcr.io/miciav/nanofaas/bash-json-transform:v0.10.0
       timeoutMs: 10000
@@ -118,6 +153,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: word-stats-java-lite
       image: ghcr.io/miciav/nanofaas/java-lite-word-stats:v0.10.0
       timeoutMs: 10000
@@ -125,6 +167,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
     - name: json-transform-java-lite
       image: ghcr.io/miciav/nanofaas/java-lite-json-transform:v0.10.0
       timeoutMs: 10000
@@ -132,6 +181,13 @@ demos:
       queueSize: 50
       maxRetries: 3
       executionMode: DEPLOYMENT
+      scalingConfig:
+        strategy: INTERNAL
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: in_flight
+            target: "2"
 
   registerJob:
     image: curlimages/curl:latest

--- a/scripts/e2e-k3s-helm.sh
+++ b/scripts/e2e-k3s-helm.sh
@@ -106,8 +106,8 @@ sync_and_build() {
     e2e_sync_project_to_vm "${PROJECT_ROOT}" "${VM_NAME}" "/home/ubuntu/nanofaas"
 
     log "Building JARs and distributions..."
-    vm_exec "cd /home/ubuntu/nanofaas && ./gradlew :control-plane:bootJar :function-runtime:bootJar :examples:java:word-stats:bootJar :examples:java:json-transform:bootJar :examples:java:word-stats-lite:installDist :examples:java:json-transform-lite:installDist --no-daemon -q"
-    log "JARs and distributions built"
+    vm_exec "cd /home/ubuntu/nanofaas && ./gradlew :control-plane:bootJar :function-runtime:bootJar :examples:java:word-stats:bootJar :examples:java:json-transform:bootJar --no-daemon -q"
+    log "JARs built"
 
     log "Building Docker images..."
 
@@ -125,9 +125,9 @@ sync_and_build() {
     vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${BASH_WORD_STATS_IMAGE} -f examples/bash/word-stats/Dockerfile ."
     vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${BASH_JSON_TRANSFORM_IMAGE} -f examples/bash/json-transform/Dockerfile ."
 
-    # Java lite demo images
-    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${JAVA_LITE_WORD_STATS_IMAGE} -f examples/java/word-stats-lite/Dockerfile examples/java/word-stats-lite/"
-    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${JAVA_LITE_JSON_TRANSFORM_IMAGE} -f examples/java/json-transform-lite/Dockerfile examples/java/json-transform-lite/"
+    # Java lite demo images (native compilation via multi-stage, needs repo root context)
+    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${JAVA_LITE_WORD_STATS_IMAGE} -f examples/java/word-stats-lite/Dockerfile ."
+    vm_exec "cd /home/ubuntu/nanofaas && sudo docker build -t ${JAVA_LITE_JSON_TRANSFORM_IMAGE} -f examples/java/json-transform-lite/Dockerfile ."
 
     log "All images built"
 }

--- a/scripts/e2e-loadtest.sh
+++ b/scripts/e2e-loadtest.sh
@@ -123,12 +123,14 @@ run_tests() {
 
         log "━━━ ${test} ━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+        # Allow k6 to exit non-zero when thresholds are crossed (report handles it)
         k6 run \
             --env "NANOFAAS_URL=${nanofaas_url}" \
             --summary-export="${RESULTS_DIR}/${test}.json" \
             "${script}" 2>&1 | tee "${RESULTS_DIR}/${test}.log" \
             | grep -E "█|✓|✗|http_req_duration\b|http_req_failed\b|http_reqs\b|iterations\b|default" \
-            | grep -v "running ("
+            | grep -v "running (" \
+            || true
 
         log "Results saved: ${RESULTS_DIR}/${test}.json"
         echo ""

--- a/scripts/release-manager/release.py
+++ b/scripts/release-manager/release.py
@@ -294,15 +294,13 @@ def build_and_push_arm64(version):
         )
         run_command(f"docker push {img}")
 
-    # 7. Java Lite Demo Functions
-    console.print("[blue]Building Java Lite distributions...[/blue]")
-    run_command("./gradlew :examples:java:word-stats-lite:installDist :examples:java:json-transform-lite:installDist")
+    # 7. Java Lite Demo Functions (native image via multi-stage Dockerfile)
     for example in ["word-stats", "json-transform"]:
         img = f"{base_image}/java-lite-{example}:{tag}-arm64"
-        console.print(f"[blue]Building Java Lite {example} ({img})...[/blue]")
-        run_command(
+        console.print(f"[blue]Building Java Lite {example} native image ({img})...[/blue]")
+        run_with_disk_retry(
             f"docker build --platform {platform} --label org.opencontainers.image.source={oci_source} "
-            f"-t {img} -f examples/java/{example}-lite/Dockerfile examples/java/{example}-lite/"
+            f"-t {img} -f examples/java/{example}-lite/Dockerfile ."
         )
         run_command(f"docker push {img}")
 


### PR DESCRIPTION
- Make Spring SDK callback fire-and-forget using virtual threads (same
  pattern as Lite SDK fix) to eliminate ~2s blocking on response path
- Add Prometheus connectivity check and metric name auto-discovery to
  loadtest script for diagnosing empty metric tables
- Enable INTERNAL autoscaling (1-5 replicas, in_flight target 2) for
  all 8 demo functions in Helm values and loadtest registry script
- Switch Lite SDK Dockerfiles to GraalVM native-image multi-stage builds
- Update CI, release, and e2e scripts for native build context

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
