### PR TITLE
Fix function-runtime AOT RuntimeSettings wiring

### DIFF
--- a/function-sdk-java/src/main/java/it/unimib/datai/nanofaas/sdk/autoconfigure/NanofaasAutoConfiguration.java
+++ b/function-sdk-java/src/main/java/it/unimib/datai/nanofaas/sdk/autoconfigure/NanofaasAutoConfiguration.java
@@ -1,6 +1,9 @@
 package it.unimib.datai.nanofaas.sdk.autoconfigure;
 
+import it.unimib.datai.nanofaas.sdk.runtime.RuntimeSettings;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 
 /**
@@ -10,4 +13,13 @@ import org.springframework.context.annotation.ComponentScan;
 @AutoConfiguration
 @ComponentScan("it.unimib.datai.nanofaas.sdk.runtime")
 public class NanofaasAutoConfiguration {
+
+    @Bean
+    RuntimeSettings runtimeSettings(
+            @Value("${EXECUTION_ID:}") String executionId,
+            @Value("${TRACE_ID:}") String traceId,
+            @Value("${CALLBACK_URL:}") String callbackUrl,
+            @Value("${FUNCTION_HANDLER:}") String functionHandler) {
+        return new RuntimeSettings(executionId, traceId, callbackUrl, functionHandler);
+    }
 }

--- a/function-sdk-java/src/main/java/it/unimib/datai/nanofaas/sdk/runtime/RuntimeSettings.java
+++ b/function-sdk-java/src/main/java/it/unimib/datai/nanofaas/sdk/runtime/RuntimeSettings.java
@@ -1,14 +1,10 @@
 package it.unimib.datai.nanofaas.sdk.runtime;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-@Component
 public record RuntimeSettings(
-        @Value("${EXECUTION_ID:}") String executionId,
-        @Value("${TRACE_ID:}") String traceId,
-        @Value("${CALLBACK_URL:}") String callbackUrl,
-        @Value("${FUNCTION_HANDLER:}") String functionHandler) {
+        String executionId,
+        String traceId,
+        String callbackUrl,
+        String functionHandler) {
 
     public RuntimeSettings {
         executionId = normalize(executionId);

--- a/function-sdk-java/src/test/java/it/unimib/datai/nanofaas/sdk/autoconfigure/NanofaasAutoConfigurationTest.java
+++ b/function-sdk-java/src/test/java/it/unimib/datai/nanofaas/sdk/autoconfigure/NanofaasAutoConfigurationTest.java
@@ -1,0 +1,50 @@
+package it.unimib.datai.nanofaas.sdk.autoconfigure;
+
+import it.unimib.datai.nanofaas.common.runtime.FunctionHandler;
+import it.unimib.datai.nanofaas.sdk.runtime.RuntimeSettings;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NanofaasAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withUserConfiguration(NanofaasAutoConfiguration.class)
+                    .withBean("testHandler", FunctionHandler.class, () -> request -> "ok");
+
+    @Test
+    void runtimeSettings_bindsAndNormalizesEnvironmentValues() {
+        contextRunner
+                .withPropertyValues(
+                        "EXECUTION_ID=exec-123",
+                        "TRACE_ID=trace-456",
+                        "CALLBACK_URL=http://callback",
+                        "FUNCTION_HANDLER=testHandler")
+                .run(context -> {
+                    RuntimeSettings runtimeSettings = context.getBean(RuntimeSettings.class);
+                    assertThat(runtimeSettings.executionId()).isEqualTo("exec-123");
+                    assertThat(runtimeSettings.traceId()).isEqualTo("trace-456");
+                    assertThat(runtimeSettings.callbackUrl()).isEqualTo("http://callback");
+                    assertThat(runtimeSettings.functionHandler()).isEqualTo("testHandler");
+                });
+    }
+
+    @Test
+    void runtimeSettings_convertsBlankValuesToNull() {
+        contextRunner
+                .withPropertyValues(
+                        "EXECUTION_ID= ",
+                        "TRACE_ID=",
+                        "CALLBACK_URL=\t",
+                        "FUNCTION_HANDLER=")
+                .run(context -> {
+                    RuntimeSettings runtimeSettings = context.getBean(RuntimeSettings.class);
+                    assertThat(runtimeSettings.executionId()).isNull();
+                    assertThat(runtimeSettings.traceId()).isNull();
+                    assertThat(runtimeSettings.callbackUrl()).isNull();
+                    assertThat(runtimeSettings.functionHandler()).isNull();
+                });
+    }
+}


### PR DESCRIPTION
## Summary
- move RuntimeSettings bean creation into SDK auto-configuration instead of component-scanning the record
- keep RuntimeSettings as a normalized value type while avoiding native/AOT field autowiring on record components
- add regression coverage for env binding and blank value normalization

## Test Plan
- [x] ./gradlew :function-sdk-java:test --tests 'it.unimib.datai.nanofaas.sdk.autoconfigure.NanofaasAutoConfigurationTest'
- [x] ./gradlew :function-runtime:test