### PR TITLE
Modify quickstart commands for function-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Minimal, high-performance FaaS control plane and Java function runtime designed 
 
 ## Quickstart (local)
 
+Invoke these commands in 2 different terminals:
 ```bash
 ./gradlew :control-plane:bootRun
-./gradlew :function-runtime:bootRun
+```
+
+```bash
+SERVER_PORT=8082 ./gradlew :function-runtime:bootRun
 ```
 
 `bootRun` includes all optional control-plane modules by default.


### PR DESCRIPTION
Quando avvio nanofaas in locale la documentazione non spiega che entrambe le applicazioni (control-plane e function-runtime) si avviano sulla stessa porta (8080).
Ora il function-runtime viene avviato su un'altra e non va in conflitto.