### PR TITLE
Render Helm charts in probe contract test

### DIFF
--- a/.github/workflows/gitops.yml
+++ b/.github/workflows/gitops.yml
@@ -21,6 +21,10 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.18.4
       - name: Run Tests
         run: ./gradlew test
 

--- a/control-plane-modules/k8s-deployment-provider/src/test/java/it/unimib/datai/nanofaas/modules/k8s/e2e/K8sE2eDeploymentSpecTest.java
+++ b/control-plane-modules/k8s-deployment-provider/src/test/java/it/unimib/datai/nanofaas/modules/k8s/e2e/K8sE2eDeploymentSpecTest.java
@@ -1,55 +1,66 @@
 package it.unimib.datai.nanofaas.modules.k8s.e2e;
 
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class K8sE2eDeploymentSpecTest {
 
+    private static final Duration HELM_TEMPLATE_TIMEOUT = Duration.ofSeconds(30);
+
     @Test
-    void controlPlaneHelmChart_exposesManagementHealthProbes() throws Exception {
-        String template = helmTemplate("helm/nanofaas/templates/control-plane-deployment.yaml");
+    void controlPlaneHelmChart_rendersManagementHealthProbes() throws Exception {
+        Container container = renderedDeployment("nanofaas", "helm/nanofaas", "nanofaas-control-plane")
+                .getSpec().getTemplate().getSpec().getContainers().getFirst();
 
         assertAll(
-                () -> assertTemplateContains(
-                        template,
-                        "readinessProbe:\n" +
-                                "            httpGet:\n" +
-                                "              path: /actuator/health/readiness\n" +
-                                "              port: {{ .Values.controlPlane.service.ports.actuator }}"),
-                () -> assertTemplateContains(
-                        template,
-                        "livenessProbe:\n" +
-                                "            httpGet:\n" +
-                                "              path: /actuator/health/liveness\n" +
-                                "              port: {{ .Values.controlPlane.service.ports.actuator }}")
+                () -> assertHttpProbe(
+                        container.getReadinessProbe(),
+                        "control-plane readinessProbe",
+                        "/actuator/health/readiness",
+                        8081),
+                () -> assertHttpProbe(
+                        container.getLivenessProbe(),
+                        "control-plane livenessProbe",
+                        "/actuator/health/liveness",
+                        8081)
         );
     }
 
     @Test
-    void functionRuntimeHelmChart_exposesHttpHealthProbes() throws Exception {
-        String template = helmTemplate("helm/nanofaas-runtime/templates/deployment.yaml");
+    void functionRuntimeHelmChart_rendersHttpHealthProbes() throws Exception {
+        Container container = renderedDeployment("runtime", "helm/nanofaas-runtime", "runtime")
+                .getSpec().getTemplate().getSpec().getContainers().getFirst();
 
         assertAll(
-                () -> assertTemplateContains(
-                        template,
-                        "readinessProbe:\n" +
-                                "            httpGet:\n" +
-                                "              path: /actuator/health/readiness\n" +
-                                "              port: {{ .Values.functionRuntime.service.port }}"),
-                () -> assertTemplateContains(
-                        template,
-                        "livenessProbe:\n" +
-                                "            httpGet:\n" +
-                                "              path: /actuator/health/liveness\n" +
-                                "              port: {{ .Values.functionRuntime.service.port }}")
+                () -> assertHttpProbe(
+                        container.getReadinessProbe(),
+                        "function-runtime readinessProbe",
+                        "/actuator/health/readiness",
+                        8080),
+                () -> assertHttpProbe(
+                        container.getLivenessProbe(),
+                        "function-runtime livenessProbe",
+                        "/actuator/health/liveness",
+                        8080)
         );
     }
 
@@ -64,8 +75,76 @@ class K8sE2eDeploymentSpecTest {
         );
     }
 
-    private static String helmTemplate(String repoRelativePath) throws IOException {
-        return Files.readString(repoRoot().resolve(repoRelativePath));
+    private static Deployment renderedDeployment(
+            String releaseName,
+            String chartRepoRelativePath,
+            String deploymentName) throws Exception {
+        List<Deployment> deployments = renderedResources(releaseName, chartRepoRelativePath).stream()
+                .filter(Deployment.class::isInstance)
+                .map(Deployment.class::cast)
+                .toList();
+
+        return deployments.stream()
+                .filter(deployment -> deploymentName.equals(deployment.getMetadata().getName()))
+                .findFirst()
+                .orElseGet(() -> fail("Expected Helm chart " + chartRepoRelativePath
+                        + " to render Deployment " + deploymentName
+                        + "; rendered deployments: " + deployments.stream()
+                        .map(deployment -> deployment.getMetadata().getName())
+                        .toList()));
+    }
+
+    private static List<KubernetesResource> renderedResources(
+            String releaseName,
+            String chartRepoRelativePath) throws Exception {
+        Object decoded = Serialization.unmarshal(
+                renderHelmChart(releaseName, chartRepoRelativePath),
+                KubernetesResource.class);
+
+        if (decoded instanceof List<?> resources) {
+            assertFalse(resources.isEmpty(), "helm template should render at least one Kubernetes resource");
+            return resources.stream()
+                    .map(resource -> assertInstanceOf(
+                            KubernetesResource.class,
+                            resource,
+                            "helm template rendered a non-Kubernetes resource"))
+                    .toList();
+        }
+
+        return List.of(assertInstanceOf(
+                KubernetesResource.class,
+                decoded,
+                "helm template rendered a non-Kubernetes resource"));
+    }
+
+    private static String renderHelmChart(String releaseName, String chartRepoRelativePath) throws Exception {
+        Path chartPath = repoRoot().resolve(chartRepoRelativePath);
+        Process process;
+        try {
+            process = new ProcessBuilder(
+                    "helm",
+                    "template",
+                    releaseName,
+                    chartPath.toString(),
+                    "--namespace",
+                    "nanofaas")
+                    .directory(repoRoot().toFile())
+                    .redirectErrorStream(true)
+                    .start();
+        } catch (IOException e) {
+            throw new AssertionError("helm must be installed and available on PATH to validate rendered charts", e);
+        }
+
+        if (!process.waitFor(HELM_TEMPLATE_TIMEOUT.toSeconds(), TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            fail("helm template timed out for chart " + chartRepoRelativePath);
+        }
+
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        if (process.exitValue() != 0) {
+            fail("helm template failed for chart " + chartRepoRelativePath + ":\n" + output);
+        }
+        return output;
     }
 
     private static Path repoRoot() {
@@ -80,9 +159,16 @@ class K8sE2eDeploymentSpecTest {
         throw new IllegalStateException("Unable to locate repository root from working directory");
     }
 
-    private static void assertTemplateContains(String template, String expected) {
-        assertTrue(
-                template.contains(expected),
-                () -> "Expected Helm template to contain:\n" + expected);
+    private static void assertHttpProbe(Probe probe, String probeName, String path, int port) {
+        if (probe == null) {
+            fail(probeName + " should be configured");
+        }
+        if (probe.getHttpGet() == null) {
+            fail(probeName + " should use httpGet");
+        }
+        assertAll(
+                () -> assertEquals(path, probe.getHttpGet().getPath()),
+                () -> assertEquals(Integer.valueOf(port), probe.getHttpGet().getPort().getIntVal())
+        );
     }
 }


### PR DESCRIPTION
Summary:
- render Helm charts in K8sE2eDeploymentSpecTest before asserting probe contracts
- install Helm in the Java CI job

Tests:
- ./gradlew :control-plane-modules:k8s-deployment-provider:test --tests '*K8sE2eDeploymentSpecTest'
- ./gradlew :control-plane-modules:k8s-deployment-provider:test
- ./gradlew test (fails locally in :nanofaas-cli:test because Docker socket is unavailable)