### PR TITLE
Add controlplane package architecture checks

### DIFF
--- a/docs/plans/2026-05-04-package-architecture-checks.md
+++ b/docs/plans/2026-05-04-package-architecture-checks.md
@@ -1,0 +1,806 @@
+# Package Architecture Checks Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add automated checks and reports that measure and guard internal package cohesion and inter-package coupling for `tools/controlplane/src/controlplane_tool`.
+
+**Architecture:** Use `import-linter` as the hard architectural gate for forbidden imports and package layering rules. Use a small `grimp`-based report command for quantitative coupling/cohesion metrics, with `pydeps` documented as an optional visual exploration tool and GitNexus retained for impact analysis before refactors.
+
+**Tech Stack:** Python 3.12, uv dependency groups, pytest, import-linter, grimp, pydeps, GitNexus MCP.
+
+---
+
+## Current Package Model
+
+The target package tree is:
+
+```text
+controlplane_tool.app             entrypoints, paths, profiles, settings
+controlplane_tool.building        Gradle, image, module build operations
+controlplane_tool.cli             Typer command groups
+controlplane_tool.cli_validation  CLI validation scenarios and runners
+controlplane_tool.core            shared primitives, models, process helpers
+controlplane_tool.e2e             E2E runners
+controlplane_tool.functions       function catalog and control-plane API helpers
+controlplane_tool.infra           VM, runtime, registry, Prometheus, Kubernetes support
+controlplane_tool.loadtest        k6, load-test flow, metrics gate, reports
+controlplane_tool.orchestation    flow catalog, local flow orchestration, Prefect adapters
+controlplane_tool.scenario        scenario models, planner, component library
+controlplane_tool.sut             SUT preflight helpers
+controlplane_tool.tui             interactive TUI
+controlplane_tool.workflow        workflow events, progress, sink models
+```
+
+Architectural intent:
+
+```text
+core       -> must stay independent from feature packages
+tui        -> UI layer only; no runtime/core package should import it
+cli        -> command surface; lower-level packages should not import it
+app        -> entrypoint/config surface; avoid importing app.main from internals
+workflow   -> shared event/progress primitives; must not import TUI or CLI
+```
+
+Do not try to fully freeze every dependency in the first pass. Start with rules that express obvious boundaries and add stricter layer contracts only after the report shows the current graph.
+
+---
+
+### Task 1: Add Architecture Tooling Dependencies
+
+**Files:**
+- Modify: `tools/controlplane/pyproject.toml`
+- Modify: `tools/controlplane/uv.lock`
+
+**Step 1: Add dev dependencies**
+
+Run from repo root:
+
+```bash
+cd tools/controlplane
+uv add --dev import-linter grimp pydeps
+```
+
+Expected:
+
+```text
+Resolved ...
+Prepared ...
+Installed ...
+```
+
+**Step 2: Verify commands are available**
+
+Run:
+
+```bash
+uv run lint-imports --help
+uv run python -c "import grimp; import pydeps; print('ok')"
+```
+
+Expected:
+
+```text
+Usage: lint-imports ...
+ok
+```
+
+**Step 3: Inspect dependency diff**
+
+Run:
+
+```bash
+git diff -- pyproject.toml uv.lock
+```
+
+Expected: `import-linter`, `grimp`, and `pydeps` are added only to the dev dependency group / lockfile.
+
+**Step 4: Commit**
+
+```bash
+git add tools/controlplane/pyproject.toml tools/controlplane/uv.lock
+git commit -m "Add package architecture tooling"
+```
+
+---
+
+### Task 2: Add Initial Import-Linter Contracts
+
+**Files:**
+- Create: `tools/controlplane/.importlinter`
+- Test: command-level verification with `uv run lint-imports`
+
+**Step 1: Create the initial contract file**
+
+Create `tools/controlplane/.importlinter`:
+
+```ini
+[importlinter]
+root_package = controlplane_tool
+
+[importlinter:contract:core_is_independent]
+name = core must not import feature packages
+type = forbidden
+source_modules =
+    controlplane_tool.core
+forbidden_modules =
+    controlplane_tool.app
+    controlplane_tool.building
+    controlplane_tool.cli
+    controlplane_tool.cli_validation
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.tui
+    controlplane_tool.workflow
+
+[importlinter:contract:no_runtime_dependency_on_tui]
+name = runtime packages must not depend on tui
+type = forbidden
+source_modules =
+    controlplane_tool.app
+    controlplane_tool.building
+    controlplane_tool.cli
+    controlplane_tool.cli_validation
+    controlplane_tool.core
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.workflow
+forbidden_modules =
+    controlplane_tool.tui
+
+[importlinter:contract:no_lower_level_dependency_on_cli]
+name = lower-level packages must not depend on cli command modules
+type = forbidden
+source_modules =
+    controlplane_tool.building
+    controlplane_tool.cli_validation
+    controlplane_tool.core
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.workflow
+forbidden_modules =
+    controlplane_tool.cli
+```
+
+**Step 2: Run the contracts**
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run lint-imports
+```
+
+Expected:
+
+```text
+Contracts: 3 kept, 0 broken.
+```
+
+If a contract fails, do not weaken it immediately. Inspect the import path and decide whether the dependency is a real boundary violation or whether the first contract is too broad for the current architecture.
+
+**Step 3: Commit**
+
+```bash
+git add tools/controlplane/.importlinter
+git commit -m "Add initial controlplane import contracts"
+```
+
+---
+
+### Task 3: Add Pytest Coverage for Import Contracts
+
+**Files:**
+- Create: `tools/controlplane/tests/test_import_contracts.py`
+
+**Step 1: Write the failing test**
+
+Create `tools/controlplane/tests/test_import_contracts.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+def test_controlplane_import_contracts_pass() -> None:
+    tool_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        ["uv", "run", "lint-imports"],
+        cwd=tool_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+```
+
+**Step 2: Run test**
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run pytest tests/test_import_contracts.py -q
+```
+
+Expected:
+
+```text
+1 passed
+```
+
+**Step 3: Run package layout tests together**
+
+Run:
+
+```bash
+uv run pytest tests/test_package_layout.py tests/test_import_contracts.py -q
+```
+
+Expected:
+
+```text
+3 passed
+```
+
+**Step 4: Commit**
+
+```bash
+git add tools/controlplane/tests/test_import_contracts.py
+git commit -m "Test controlplane import contracts"
+```
+
+---
+
+### Task 4: Add Package Coupling Report Command
+
+**Files:**
+- Create: `tools/controlplane/src/controlplane_tool/devtools/__init__.py`
+- Create: `tools/controlplane/src/controlplane_tool/devtools/package_report.py`
+- Modify: `tools/controlplane/pyproject.toml`
+- Test: `tools/controlplane/tests/test_package_report.py`
+
+**Step 1: Write failing tests**
+
+Create `tools/controlplane/tests/test_package_report.py`:
+
+```python
+from __future__ import annotations
+
+from controlplane_tool.devtools.package_report import (
+    PackageMetrics,
+    calculate_metrics,
+    format_metrics_table,
+)
+
+
+def test_calculate_metrics_counts_internal_outgoing_and_incoming_edges() -> None:
+    metrics = calculate_metrics(
+        packages=[
+            "controlplane_tool.core",
+            "controlplane_tool.loadtest",
+            "controlplane_tool.tui",
+        ],
+        edges=[
+            ("controlplane_tool.core.models", "controlplane_tool.core.net_utils"),
+            ("controlplane_tool.loadtest.k6_ops", "controlplane_tool.core.models"),
+            ("controlplane_tool.tui.app", "controlplane_tool.loadtest.loadtest_models"),
+        ],
+    )
+
+    by_package = {metric.package: metric for metric in metrics}
+
+    assert by_package["controlplane_tool.core"] == PackageMetrics(
+        package="controlplane_tool.core",
+        internal_imports=1,
+        outgoing_imports=0,
+        incoming_imports=2,
+        instability=0.0,
+    )
+    assert by_package["controlplane_tool.loadtest"] == PackageMetrics(
+        package="controlplane_tool.loadtest",
+        internal_imports=0,
+        outgoing_imports=1,
+        incoming_imports=1,
+        instability=0.5,
+    )
+    assert by_package["controlplane_tool.tui"] == PackageMetrics(
+        package="controlplane_tool.tui",
+        internal_imports=0,
+        outgoing_imports=1,
+        incoming_imports=0,
+        instability=1.0,
+    )
+
+
+def test_format_metrics_table_includes_header_and_package_rows() -> None:
+    table = format_metrics_table(
+        [
+            PackageMetrics(
+                package="controlplane_tool.core",
+                internal_imports=1,
+                outgoing_imports=0,
+                incoming_imports=2,
+                instability=0.0,
+            )
+        ]
+    )
+
+    assert "package" in table
+    assert "internal" in table
+    assert "outgoing" in table
+    assert "incoming" in table
+    assert "instability" in table
+    assert "controlplane_tool.core" in table
+```
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run pytest tests/test_package_report.py -q
+```
+
+Expected:
+
+```text
+ModuleNotFoundError: No module named 'controlplane_tool.devtools'
+```
+
+**Step 2: Add the devtools package**
+
+Create `tools/controlplane/src/controlplane_tool/devtools/__init__.py`:
+
+```python
+from __future__ import annotations
+```
+
+**Step 3: Add the report implementation**
+
+Create `tools/controlplane/src/controlplane_tool/devtools/package_report.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+import argparse
+from collections.abc import Iterable, Sequence
+
+import grimp
+
+
+ROOT_PACKAGE = "controlplane_tool"
+TOP_LEVEL_PACKAGES = (
+    "controlplane_tool.app",
+    "controlplane_tool.building",
+    "controlplane_tool.cli",
+    "controlplane_tool.cli_validation",
+    "controlplane_tool.core",
+    "controlplane_tool.e2e",
+    "controlplane_tool.functions",
+    "controlplane_tool.infra",
+    "controlplane_tool.loadtest",
+    "controlplane_tool.orchestation",
+    "controlplane_tool.scenario",
+    "controlplane_tool.sut",
+    "controlplane_tool.tui",
+    "controlplane_tool.workflow",
+)
+
+
+@dataclass(frozen=True)
+class PackageMetrics:
+    package: str
+    internal_imports: int
+    outgoing_imports: int
+    incoming_imports: int
+    instability: float
+
+
+def _top_level_package(module: str, packages: Sequence[str]) -> str | None:
+    for package in packages:
+        if module == package or module.startswith(f"{package}."):
+            return package
+    return None
+
+
+def calculate_metrics(
+    *,
+    packages: Sequence[str],
+    edges: Iterable[tuple[str, str]],
+) -> list[PackageMetrics]:
+    internal_counts = {package: 0 for package in packages}
+    outgoing_counts = {package: 0 for package in packages}
+    incoming_counts = {package: 0 for package in packages}
+
+    for importer, imported in edges:
+        importer_package = _top_level_package(importer, packages)
+        imported_package = _top_level_package(imported, packages)
+        if importer_package is None or imported_package is None:
+            continue
+        if importer_package == imported_package:
+            internal_counts[importer_package] += 1
+            continue
+        outgoing_counts[importer_package] += 1
+        incoming_counts[imported_package] += 1
+
+    metrics: list[PackageMetrics] = []
+    for package in packages:
+        outgoing = outgoing_counts[package]
+        incoming = incoming_counts[package]
+        denominator = incoming + outgoing
+        instability = round(outgoing / denominator, 2) if denominator else 0.0
+        metrics.append(
+            PackageMetrics(
+                package=package,
+                internal_imports=internal_counts[package],
+                outgoing_imports=outgoing,
+                incoming_imports=incoming,
+                instability=instability,
+            )
+        )
+    return metrics
+
+
+def format_metrics_table(metrics: Sequence[PackageMetrics]) -> str:
+    header = f"{'package':38} {'internal':>8} {'outgoing':>8} {'incoming':>8} {'instability':>11}"
+    rows = [header, "-" * len(header)]
+    for metric in metrics:
+        rows.append(
+            f"{metric.package:38} "
+            f"{metric.internal_imports:8d} "
+            f"{metric.outgoing_imports:8d} "
+            f"{metric.incoming_imports:8d} "
+            f"{metric.instability:11.2f}"
+        )
+    return "\n".join(rows)
+
+
+def _iter_grimp_edges(root_package: str) -> list[tuple[str, str]]:
+    graph = grimp.build_graph(root_package, include_external_packages=False)
+    modules = sorted(
+        module
+        for module in graph.modules
+        if module == root_package or module.startswith(f"{root_package}.")
+    )
+    edges: list[tuple[str, str]] = []
+    for importer in modules:
+        for imported in sorted(graph.find_modules_directly_imported_by(importer)):
+            if imported == root_package or imported.startswith(f"{root_package}."):
+                edges.append((importer, imported))
+    return edges
+
+
+def build_current_metrics() -> list[PackageMetrics]:
+    return calculate_metrics(
+        packages=TOP_LEVEL_PACKAGES,
+        edges=_iter_grimp_edges(ROOT_PACKAGE),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report internal and cross-package imports for controlplane_tool."
+    )
+    parser.parse_args()
+    print(format_metrics_table(build_current_metrics()))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 4: Add command entrypoint**
+
+Modify `tools/controlplane/pyproject.toml`:
+
+```toml
+[project.scripts]
+controlplane-tool = "controlplane_tool.app.main:main"
+controlplane-package-report = "controlplane_tool.devtools.package_report:main"
+```
+
+**Step 5: Run tests**
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run pytest tests/test_package_report.py -q
+```
+
+Expected:
+
+```text
+2 passed
+```
+
+**Step 6: Run the report command**
+
+Run:
+
+```bash
+uv run controlplane-package-report
+```
+
+Expected: a table with one row for each top-level package and no traceback.
+
+**Step 7: Commit**
+
+```bash
+git add tools/controlplane/pyproject.toml \
+  tools/controlplane/src/controlplane_tool/devtools \
+  tools/controlplane/tests/test_package_report.py
+git commit -m "Add controlplane package coupling report"
+```
+
+---
+
+### Task 5: Add Documentation for Architecture Checks
+
+**Files:**
+- Modify: `tools/controlplane/README.md`
+
+**Step 1: Write a documentation test first**
+
+Append to `tools/controlplane/tests/test_wrapper_docs.py` or create `tools/controlplane/tests/test_architecture_docs.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.app.paths import resolve_workspace_path
+
+
+def test_tool_readme_documents_package_architecture_checks() -> None:
+    readme = resolve_workspace_path(Path("tools/controlplane/README.md")).read_text(
+        encoding="utf-8"
+    )
+
+    assert "Package architecture checks" in readme
+    assert "uv run lint-imports" in readme
+    assert "uv run controlplane-package-report" in readme
+    assert "uv run pydeps controlplane_tool" in readme
+    assert "GitNexus" in readme
+```
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run pytest tests/test_architecture_docs.py -q
+```
+
+Expected:
+
+```text
+FAILED ... AssertionError
+```
+
+**Step 2: Add README section**
+
+Append this section to `tools/controlplane/README.md` near the developer/testing commands:
+
+```markdown
+## Package architecture checks
+
+The Python package is split into semantic packages under `controlplane_tool/`.
+Use the import contracts as the hard boundary check:
+
+```bash
+uv run lint-imports
+```
+
+Use the coupling report to inspect package cohesion and cross-package imports:
+
+```bash
+uv run controlplane-package-report
+```
+
+Use `pydeps` for a visual graph when investigating a dependency tangle:
+
+```bash
+uv run pydeps controlplane_tool --show-deps --max-bacon 2
+```
+
+Use GitNexus before moving public symbols or changing flow-level dependencies:
+
+```text
+gitnexus_context({name: "LoadtestRunner"})
+gitnexus_impact({target: "LoadtestRunner", direction: "upstream"})
+gitnexus_detect_changes({scope: "staged"})
+```
+```
+
+**Step 3: Run documentation test**
+
+Run:
+
+```bash
+uv run pytest tests/test_architecture_docs.py -q
+```
+
+Expected:
+
+```text
+1 passed
+```
+
+**Step 4: Commit**
+
+```bash
+git add tools/controlplane/README.md tools/controlplane/tests/test_architecture_docs.py
+git commit -m "Document controlplane package architecture checks"
+```
+
+---
+
+### Task 6: Add Full Verification Gate
+
+**Files:**
+- No new files unless a failure requires a narrow fix.
+
+**Step 1: Run import contracts**
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run lint-imports
+```
+
+Expected:
+
+```text
+Contracts: 3 kept, 0 broken.
+```
+
+**Step 2: Run package report**
+
+Run:
+
+```bash
+uv run controlplane-package-report
+```
+
+Expected:
+
+```text
+package                                internal outgoing incoming instability
+...
+controlplane_tool.core
+...
+```
+
+Do not assert specific metric values in the command output. The report is diagnostic; the import contracts are the gate.
+
+**Step 3: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_package_layout.py tests/test_import_contracts.py tests/test_package_report.py tests/test_architecture_docs.py -q
+```
+
+Expected:
+
+```text
+6 passed
+```
+
+The exact count may be higher if `test_package_layout.py` gains tests. Check for zero failures.
+
+**Step 4: Run full suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected:
+
+```text
+... passed
+```
+
+Current baseline before this plan is `862 passed`; the expected total after adding the new tests should increase.
+
+**Step 5: Run GitNexus staged change detection**
+
+Run through MCP:
+
+```text
+gitnexus_detect_changes({scope: "staged"})
+```
+
+Expected: risk is not HIGH or CRITICAL. If it is HIGH/CRITICAL, inspect the reported symbols before committing.
+
+**Step 6: Final commit if needed**
+
+If any fixes were needed after the earlier task commits:
+
+```bash
+git add tools/controlplane
+git commit -m "Verify package architecture checks"
+```
+
+---
+
+### Task 7: Optional CI Integration
+
+Only do this if the project already has a Python controlplane CI step that runs `uv run pytest`.
+
+**Files:**
+- Modify: `.github/workflows/*.yml` for the controlplane test job
+
+**Step 1: Locate workflow**
+
+Run:
+
+```bash
+rg -n "tools/controlplane|uv run pytest|controlplane-tool" .github/workflows
+```
+
+**Step 2: Add import contract command near pytest**
+
+Add:
+
+```yaml
+- name: Check controlplane package import contracts
+  working-directory: tools/controlplane
+  run: uv run lint-imports
+```
+
+**Step 3: Do not add package report to CI as a hard gate**
+
+The report should remain diagnostic unless a threshold is intentionally designed later.
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows
+git commit -m "Run controlplane import contracts in CI"
+```
+
+---
+
+## Follow-Up Hardening Ideas
+
+Do not implement these in the first pass unless the initial contracts are stable:
+
+1. Add an `import-linter` `layers` contract once the package layering is agreed.
+2. Add JSON output to `controlplane-package-report` for trend tracking.
+3. Add thresholds for instability only after observing a few report runs.
+4. Add a generated `package-deps.svg` artifact locally, but do not commit generated images by default.
+5. Use GitNexus impact analysis before moving any package boundary again.
+
+---
+
+## Completion Checklist
+
+- `uv run lint-imports` passes.
+- `uv run controlplane-package-report` prints a package table.
+- `uv run pytest tests/test_package_layout.py tests/test_import_contracts.py tests/test_package_report.py tests/test_architecture_docs.py -q` passes.
+- `uv run pytest -q` passes.
+- `gitnexus_detect_changes({scope: "staged"})` reviewed before final commit.
+- Documentation explains when to use import-linter, grimp report, pydeps, and GitNexus.

--- a/tools/controlplane/.importlinter
+++ b/tools/controlplane/.importlinter
@@ -1,0 +1,59 @@
+[importlinter]
+root_package = controlplane_tool
+
+[importlinter:contract:core_is_independent]
+name = core must not import feature packages
+type = forbidden
+source_modules =
+    controlplane_tool.core
+forbidden_modules =
+    controlplane_tool.app
+    controlplane_tool.building
+    controlplane_tool.cli
+    controlplane_tool.cli_validation
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.tui
+    controlplane_tool.workflow
+
+[importlinter:contract:no_runtime_dependency_on_tui]
+name = runtime packages must not depend on tui
+type = forbidden
+source_modules =
+    controlplane_tool.building
+    controlplane_tool.cli
+    controlplane_tool.cli_validation
+    controlplane_tool.core
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.workflow
+forbidden_modules =
+    controlplane_tool.tui
+
+[importlinter:contract:no_lower_level_dependency_on_cli]
+name = lower-level packages must not depend on cli command modules
+type = forbidden
+source_modules =
+    controlplane_tool.building
+    controlplane_tool.cli_validation
+    controlplane_tool.core
+    controlplane_tool.e2e
+    controlplane_tool.functions
+    controlplane_tool.infra
+    controlplane_tool.loadtest
+    controlplane_tool.orchestation
+    controlplane_tool.scenario
+    controlplane_tool.sut
+    controlplane_tool.workflow
+forbidden_modules =
+    controlplane_tool.cli

--- a/tools/controlplane/README.md
+++ b/tools/controlplane/README.md
@@ -182,6 +182,35 @@ Loadtest runs write profiles and reports under:
 - The metrics flow auto-starts a tool-managed control-plane runtime when needed.
 - Strict metric gating can be enabled with `strict_required = true`.
 
+## Package architecture checks
+
+The Python package is split into semantic packages under `controlplane_tool/`.
+Use the import contracts as the hard boundary check:
+
+```bash
+uv run lint-imports
+```
+
+Use the coupling report to inspect package cohesion and cross-package imports:
+
+```bash
+uv run controlplane-package-report
+```
+
+Use `pydeps` for a visual graph when investigating a dependency tangle:
+
+```bash
+uv run pydeps controlplane_tool --show-deps --max-bacon 2
+```
+
+Use GitNexus before moving public symbols or changing flow-level dependencies:
+
+```text
+gitnexus_context({name: "LoadtestRunner"})
+gitnexus_impact({target: "LoadtestRunner", direction: "upstream"})
+gitnexus_detect_changes({scope: "staged"})
+```
+
 ## Advanced
 
 Raw Gradle commands remain available for low-level workflows, but the wrapper-based UX above is the primary path for milestone 3.

--- a/tools/controlplane/pyproject.toml
+++ b/tools/controlplane/pyproject.toml
@@ -37,6 +37,9 @@ where = ["src"]
 
 [dependency-groups]
 dev = [
+    "grimp>=3.14",
+    "import-linter>=2.11",
+    "pydeps>=3.0.6",
     "pytest>=9.0.3",
 ]
 

--- a/tools/controlplane/pyproject.toml
+++ b/tools/controlplane/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 
 [project.scripts]
 controlplane-tool = "controlplane_tool.app.main:main"
+controlplane-package-report = "controlplane_tool.devtools.package_report:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/tools/controlplane/src/controlplane_tool/building/gradle_executor.py
+++ b/tools/controlplane/src/controlplane_tool/building/gradle_executor.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.app.paths import default_tool_paths
+from controlplane_tool.building.gradle_planner import (
+    build_gradle_command,
+    plan_module_matrix_commands,
+)
+from controlplane_tool.building.requests import BuildRequest
+from controlplane_tool.building.tasks import CommandExecutionResult
+from controlplane_tool.core.shell_backend import SubprocessShell
+
+
+class GradleCommandExecutor:
+    def __init__(self, repo_root: Path | None = None) -> None:
+        self.repo_root = repo_root or default_tool_paths().workspace_root
+        self._shell = SubprocessShell()
+
+    def _build_command(
+        self,
+        action: str,
+        profile: str,
+        modules: str | None,
+        extra_gradle_args: list[str],
+    ) -> list[str]:
+        request = BuildRequest(
+            action=action,
+            profile=profile,
+            modules=modules,
+            extra_gradle_args=extra_gradle_args,
+        )
+        return build_gradle_command(
+            repo_root=self.repo_root,
+            request=request,
+            extra_gradle_args=extra_gradle_args,
+        )
+
+    def execute(
+        self,
+        action: str,
+        profile: str,
+        modules: str | None,
+        extra_gradle_args: list[str],
+        dry_run: bool,
+    ) -> CommandExecutionResult:
+        command = self._build_command(action, profile, modules, extra_gradle_args)
+        if dry_run:
+            return CommandExecutionResult(command=command, return_code=0, dry_run=True)
+
+        completed = self._shell.run(command, cwd=self.repo_root, dry_run=False)
+        return CommandExecutionResult(
+            command=command,
+            return_code=completed.return_code,
+            dry_run=False,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+    def execute_matrix(
+        self,
+        task: str,
+        modules: str | None,
+        max_combinations: int,
+        extra_gradle_args: list[str],
+        dry_run: bool,
+    ) -> tuple[list[list[str]], int]:
+        commands = plan_module_matrix_commands(
+            repo_root=self.repo_root,
+            task=task,
+            max_combinations=max_combinations,
+            modules_csv=modules,
+            extra_gradle_args=extra_gradle_args,
+        )
+        if dry_run:
+            return commands, 0
+
+        for command in commands:
+            completed = self._shell.run(command, cwd=self.repo_root, dry_run=False)
+            if completed.return_code != 0:
+                return commands, completed.return_code
+        return commands, 0

--- a/tools/controlplane/src/controlplane_tool/cli/commands.py
+++ b/tools/controlplane/src/controlplane_tool/cli/commands.py
@@ -1,94 +1,17 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import typer
 from pydantic import ValidationError
 
-from controlplane_tool.building.requests import BuildRequest
+from controlplane_tool.building.gradle_executor import GradleCommandExecutor
 from controlplane_tool.building.tasks import CommandExecutionResult
 from controlplane_tool.orchestation.flow_catalog import resolve_flow_definition
-from controlplane_tool.building.gradle_planner import (
-    build_gradle_command,
-    plan_module_matrix_commands,
-)
-from controlplane_tool.app.paths import default_tool_paths
 from controlplane_tool.orchestation.prefect_runtime import run_local_flow
-from controlplane_tool.core.shell_backend import SubprocessShell
 
 CLI_CONTEXT_SETTINGS = {
     "allow_extra_args": True,
     "ignore_unknown_options": True,
 }
-
-class GradleCommandExecutor:
-    def __init__(self, repo_root: Path | None = None) -> None:
-        self.repo_root = repo_root or default_tool_paths().workspace_root
-        self._shell = SubprocessShell()
-
-    def _build_command(
-        self,
-        action: str,
-        profile: str,
-        modules: str | None,
-        extra_gradle_args: list[str],
-    ) -> list[str]:
-        request = BuildRequest(
-            action=action,
-            profile=profile,
-            modules=modules,
-            extra_gradle_args=extra_gradle_args,
-        )
-        return build_gradle_command(
-            repo_root=self.repo_root,
-            request=request,
-            extra_gradle_args=extra_gradle_args,
-        )
-
-    def execute(
-        self,
-        action: str,
-        profile: str,
-        modules: str | None,
-        extra_gradle_args: list[str],
-        dry_run: bool,
-    ) -> CommandExecutionResult:
-        command = self._build_command(action, profile, modules, extra_gradle_args)
-        if dry_run:
-            return CommandExecutionResult(command=command, return_code=0, dry_run=True)
-
-        completed = self._shell.run(command, cwd=self.repo_root, dry_run=False)
-        return CommandExecutionResult(
-            command=command,
-            return_code=completed.return_code,
-            dry_run=False,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
-        )
-
-    def execute_matrix(
-        self,
-        task: str,
-        modules: str | None,
-        max_combinations: int,
-        extra_gradle_args: list[str],
-        dry_run: bool,
-    ) -> tuple[list[list[str]], int]:
-        commands = plan_module_matrix_commands(
-            repo_root=self.repo_root,
-            task=task,
-            max_combinations=max_combinations,
-            modules_csv=modules,
-            extra_gradle_args=extra_gradle_args,
-        )
-        if dry_run:
-            return commands, 0
-
-        for command in commands:
-            completed = self._shell.run(command, cwd=self.repo_root, dry_run=False)
-            if completed.return_code != 0:
-                return commands, completed.return_code
-        return commands, 0
 
 
 def _combined_extra_gradle_args(

--- a/tools/controlplane/src/controlplane_tool/core/process_streaming.py
+++ b/tools/controlplane/src/controlplane_tool/core/process_streaming.py
@@ -6,7 +6,6 @@ import subprocess
 from threading import Thread
 
 from tui_toolkit import workflow_log
-from controlplane_tool.workflow.workflow_models import WorkflowContext
 
 
 def spawn_logged_process(
@@ -15,7 +14,7 @@ def spawn_logged_process(
     cwd: Path,
     env: dict[str, str] | None = None,
     log_path: Path,
-    workflow_context: WorkflowContext | None = None,
+    workflow_context: object | None = None,
 ) -> subprocess.Popen[str]:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_file = log_path.open("a", encoding="utf-8")

--- a/tools/controlplane/src/controlplane_tool/devtools/__init__.py
+++ b/tools/controlplane/src/controlplane_tool/devtools/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tools/controlplane/src/controlplane_tool/devtools/package_report.py
+++ b/tools/controlplane/src/controlplane_tool/devtools/package_report.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+import grimp
+
+
+ROOT_PACKAGE = "controlplane_tool"
+TOP_LEVEL_PACKAGES = (
+    "controlplane_tool.app",
+    "controlplane_tool.building",
+    "controlplane_tool.cli",
+    "controlplane_tool.cli_validation",
+    "controlplane_tool.core",
+    "controlplane_tool.e2e",
+    "controlplane_tool.functions",
+    "controlplane_tool.infra",
+    "controlplane_tool.loadtest",
+    "controlplane_tool.orchestation",
+    "controlplane_tool.scenario",
+    "controlplane_tool.sut",
+    "controlplane_tool.tui",
+    "controlplane_tool.workflow",
+)
+
+
+@dataclass(frozen=True)
+class PackageMetrics:
+    package: str
+    internal_imports: int
+    outgoing_imports: int
+    incoming_imports: int
+    instability: float
+
+
+def _top_level_package(module: str, packages: Sequence[str]) -> str | None:
+    for package in packages:
+        if module == package or module.startswith(f"{package}."):
+            return package
+    return None
+
+
+def calculate_metrics(
+    *,
+    packages: Sequence[str],
+    edges: Iterable[tuple[str, str]],
+) -> list[PackageMetrics]:
+    internal_counts = {package: 0 for package in packages}
+    outgoing_counts = {package: 0 for package in packages}
+    incoming_counts = {package: 0 for package in packages}
+
+    for importer, imported in edges:
+        importer_package = _top_level_package(importer, packages)
+        imported_package = _top_level_package(imported, packages)
+        if importer_package is None or imported_package is None:
+            continue
+        if importer_package == imported_package:
+            internal_counts[importer_package] += 1
+            continue
+        outgoing_counts[importer_package] += 1
+        incoming_counts[imported_package] += 1
+
+    metrics: list[PackageMetrics] = []
+    for package in packages:
+        outgoing = outgoing_counts[package]
+        incoming = incoming_counts[package]
+        denominator = incoming + outgoing
+        instability = round(outgoing / denominator, 2) if denominator else 0.0
+        metrics.append(
+            PackageMetrics(
+                package=package,
+                internal_imports=internal_counts[package],
+                outgoing_imports=outgoing,
+                incoming_imports=incoming,
+                instability=instability,
+            )
+        )
+    return metrics
+
+
+def format_metrics_table(metrics: Sequence[PackageMetrics]) -> str:
+    header = f"{'package':38} {'internal':>8} {'outgoing':>8} {'incoming':>8} {'instability':>11}"
+    rows = [header, "-" * len(header)]
+    for metric in metrics:
+        rows.append(
+            f"{metric.package:38} "
+            f"{metric.internal_imports:8d} "
+            f"{metric.outgoing_imports:8d} "
+            f"{metric.incoming_imports:8d} "
+            f"{metric.instability:11.2f}"
+        )
+    return "\n".join(rows)
+
+
+def _iter_grimp_edges(root_package: str) -> list[tuple[str, str]]:
+    graph = grimp.build_graph(root_package, include_external_packages=False)
+    modules = sorted(
+        module
+        for module in graph.modules
+        if module == root_package or module.startswith(f"{root_package}.")
+    )
+    edges: list[tuple[str, str]] = []
+    for importer in modules:
+        for imported in sorted(graph.find_modules_directly_imported_by(importer)):
+            if imported == root_package or imported.startswith(f"{root_package}."):
+                edges.append((importer, imported))
+    return edges
+
+
+def build_current_metrics() -> list[PackageMetrics]:
+    return calculate_metrics(
+        packages=TOP_LEVEL_PACKAGES,
+        edges=_iter_grimp_edges(ROOT_PACKAGE),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report internal and cross-package imports for controlplane_tool."
+    )
+    parser.parse_args()
+    print(format_metrics_table(build_current_metrics()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/controlplane/src/controlplane_tool/e2e/e2e_runner.py
+++ b/tools/controlplane/src/controlplane_tool/e2e/e2e_runner.py
@@ -7,7 +7,7 @@ from typing import Callable, Literal
 
 from multipass import MultipassClient
 
-from controlplane_tool.core.command_resolver import CommandResolver
+from controlplane_tool.scenario.command_resolver import CommandResolver
 from controlplane_tool.scenario.catalog import ScenarioDefinition, list_scenarios, resolve_scenario
 from controlplane_tool.e2e.e2e_models import E2eRequest
 from tui_toolkit import bind_workflow_context

--- a/tools/controlplane/src/controlplane_tool/orchestation/infra_flows.py
+++ b/tools/controlplane/src/controlplane_tool/orchestation/infra_flows.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import time
 
 from controlplane_tool.orchestation.adapters import ShellCommandAdapter
+from controlplane_tool.building.gradle_executor import GradleCommandExecutor
 from controlplane_tool.building.tasks import (
     CommandExecutionResult,
     api_tests_task,
@@ -144,8 +145,6 @@ def build_gradle_action_flow(
     dry_run: bool,
     executor: object | None = None,
 ) -> LocalFlowDefinition[CommandExecutionResult]:
-    from controlplane_tool.cli.commands import GradleCommandExecutor
-
     active_executor = executor or GradleCommandExecutor()
     flow_id = f"building.{action}"
     return LocalFlowDefinition(

--- a/tools/controlplane/src/controlplane_tool/scenario/command_resolver.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/command_resolver.py
@@ -1,5 +1,5 @@
 """
-command_resolver.py — Stateless placeholder substitution for scenario plan steps.
+command_resolver.py - Stateless placeholder substitution for scenario plan steps.
 
 Extracted from E2eRunner to isolate env-building from orchestration.
 """
@@ -15,7 +15,6 @@ from controlplane_tool.infra.vm.vm_models import VmRequest
 class CommandResolver:
     """Resolves <placeholder> tokens in scenario step commands and env dicts."""
 
-    # Matches the dry-run placeholder inserted by resolve_connection_host
     _MULTIPASS_IP_RE = re.compile(r"<multipass-ip:([^>]+)>")
 
     def __init__(
@@ -24,15 +23,13 @@ class CommandResolver:
     ) -> None:
         self._host_resolver = host_resolver
 
-    # ── simple generic replacement API (testable without VM) ────────────────
-
     def _replace(self, text: str, replacements: dict[str, str]) -> str:
         for key, value in replacements.items():
             text = text.replace(f"<{key}>", value)
         return text
 
     def resolve_placeholder_text(self, text: str) -> str:
-        """Return text unchanged — override point for runtime IP injection."""
+        """Return text unchanged - override point for runtime IP injection."""
         return text
 
     def resolve_command(
@@ -41,8 +38,6 @@ class CommandResolver:
         env: dict[str, str],
     ) -> list[str]:
         return [self._replace(token, env) for token in command]
-
-    # ── multipass IP resolution (used during execution) ──────────────────────
 
     def _resolve_ip(self, vm: VmOrchestrator, vm_request: VmRequest) -> str:
         """Resolve the real IP of a VM, using an injected resolver if provided."""

--- a/tools/controlplane/tests/test_architecture_docs.py
+++ b/tools/controlplane/tests/test_architecture_docs.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.app.paths import resolve_workspace_path
+
+
+def test_tool_readme_documents_package_architecture_checks() -> None:
+    readme = resolve_workspace_path(Path("tools/controlplane/README.md")).read_text(
+        encoding="utf-8"
+    )
+
+    assert "Package architecture checks" in readme
+    assert "uv run lint-imports" in readme
+    assert "uv run controlplane-package-report" in readme
+    assert "uv run pydeps controlplane_tool" in readme
+    assert "GitNexus" in readme

--- a/tools/controlplane/tests/test_command_resolver.py
+++ b/tools/controlplane/tests/test_command_resolver.py
@@ -1,4 +1,4 @@
-from controlplane_tool.core.command_resolver import CommandResolver
+from controlplane_tool.scenario.command_resolver import CommandResolver
 
 
 def test_replace_substitutes_single_placeholder() -> None:

--- a/tools/controlplane/tests/test_import_contracts.py
+++ b/tools/controlplane/tests/test_import_contracts.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+def test_controlplane_import_contracts_pass() -> None:
+    tool_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        ["uv", "run", "lint-imports"],
+        cwd=tool_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/controlplane/tests/test_package_report.py
+++ b/tools/controlplane/tests/test_package_report.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from controlplane_tool.devtools.package_report import (
+    PackageMetrics,
+    calculate_metrics,
+    format_metrics_table,
+)
+
+
+def test_calculate_metrics_counts_internal_outgoing_and_incoming_edges() -> None:
+    metrics = calculate_metrics(
+        packages=[
+            "controlplane_tool.core",
+            "controlplane_tool.loadtest",
+            "controlplane_tool.tui",
+        ],
+        edges=[
+            ("controlplane_tool.core.models", "controlplane_tool.core.net_utils"),
+            ("controlplane_tool.loadtest.k6_ops", "controlplane_tool.core.models"),
+            ("controlplane_tool.tui.app", "controlplane_tool.loadtest.loadtest_models"),
+        ],
+    )
+
+    by_package = {metric.package: metric for metric in metrics}
+
+    assert by_package["controlplane_tool.core"] == PackageMetrics(
+        package="controlplane_tool.core",
+        internal_imports=1,
+        outgoing_imports=0,
+        incoming_imports=1,
+        instability=0.0,
+    )
+    assert by_package["controlplane_tool.loadtest"] == PackageMetrics(
+        package="controlplane_tool.loadtest",
+        internal_imports=0,
+        outgoing_imports=1,
+        incoming_imports=1,
+        instability=0.5,
+    )
+    assert by_package["controlplane_tool.tui"] == PackageMetrics(
+        package="controlplane_tool.tui",
+        internal_imports=0,
+        outgoing_imports=1,
+        incoming_imports=0,
+        instability=1.0,
+    )
+
+
+def test_format_metrics_table_includes_header_and_package_rows() -> None:
+    table = format_metrics_table(
+        [
+            PackageMetrics(
+                package="controlplane_tool.core",
+                internal_imports=1,
+                outgoing_imports=0,
+                incoming_imports=2,
+                instability=0.0,
+            )
+        ]
+    )
+
+    assert "package" in table
+    assert "internal" in table
+    assert "outgoing" in table
+    assert "incoming" in table
+    assert "instability" in table
+    assert "controlplane_tool.core" in table

--- a/tools/controlplane/uv.lock
+++ b/tools/controlplane/uv.lock
@@ -415,6 +415,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "grimp" },
+    { name = "import-linter" },
+    { name = "pydeps" },
     { name = "pytest" },
 ]
 
@@ -439,7 +442,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "grimp", specifier = ">=3.14" },
+    { name = "import-linter", specifier = ">=2.11" },
+    { name = "pydeps", specifier = ">=3.0.6" },
+    { name = "pytest", specifier = ">=9.0.3" },
+]
 
 [[package]]
 name = "coolname"
@@ -753,6 +761,99 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/31/d4a86207c38954b6c3d859a1fc740a80b04bbe6e3b8a39f4e66f9633dfa4/grimp-3.14-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f1c91e3fa48c2196bf62e3c71492140d227b2bfcd6d15e735cbc0b3e2d5308e0", size = 2185572, upload-time = "2025-12-10T17:53:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/61/ed4cba5bd75d37fe46e17a602f616619a9e4f74ad8adfcf560ce4b2a1697/grimp-3.14-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6291c8f1690a9fe21b70923c60b075f4a89676541999e3d33084cbc69ac06a1", size = 2118002, upload-time = "2025-12-10T17:53:18.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6a/688f6144d0b207d7845bd8ab403820a83630ce3c9420cbbc7c9e9282f9c0/grimp-3.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ec312383935c2d09e4085c8435780ada2e13ebef14e105609c2988a02a5b2ce", size = 2283939, upload-time = "2025-12-10T17:52:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/98/4c540de151bf3fd58d6d7b3fe2269b6a6af6c61c915de1bc991802bfaff8/grimp-3.14-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4f43cbf640e73ee703ad91639591046828d20103a1c363a02516e77a66a4ac07", size = 2233693, upload-time = "2025-12-10T17:52:18.938Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/7b/84b4b52b6c6dd5bf083cb1a72945748f56ea2e61768bbebf87e8d9d0ef75/grimp-3.14-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a93c9fddccb9ff16f5c6b5fca44227f5f86cba7cffc145d2176119603d2d7c7", size = 2389745, upload-time = "2025-12-10T17:53:00.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/33/31b96907c7dd78953df5e1ce67c558bd6057220fa1203d28d52566315a2e/grimp-3.14-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5653a2769fdc062cb7598d12200352069c9c6559b6643af6ada3639edb98fcc3", size = 2569055, upload-time = "2025-12-10T17:52:33.556Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/24/ce1a8110f3d5b178153b903aafe54b6a9216588b5bff3656e30af43e9c29/grimp-3.14-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:071c7ddf5e5bb7b2fdf79aefdf6e1c237cd81c095d6d0a19620e777e85bf103c", size = 2358044, upload-time = "2025-12-10T17:52:47.545Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7f/16d98c02287bc99884843478b9a68b04a2ef13b5cb8b9f36a9ca7daea75b/grimp-3.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e01b7a4419f535b667dfdcb556d3815b52981474f791fb40d72607228389a31", size = 2310304, upload-time = "2025-12-10T17:53:09.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8c/0fde9781b0f6b4f9227d485685f48f6bcc70b95af22e2f85ff7f416cbfc1/grimp-3.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c29682f336151d1d018d0c3aa9eeaa35734b970e4593fa396b901edca7ef5c79", size = 2463682, upload-time = "2025-12-10T17:53:49.185Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cb/2baff301c2c2cc2792b6e225ea0784793ca587c81b97572be0bad122cfc8/grimp-3.14-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:a5c4fd71f363ea39e8aab0630010ced77a8de9789f27c0acdd0d7e6269d4a8ef", size = 2500573, upload-time = "2025-12-10T17:54:03.899Z" },
+    { url = "https://files.pythonhosted.org/packages/96/69/797e4242f42d6665da5fe22cb250cae3f14ece4cb22ad153e9cd97158179/grimp-3.14-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:766911e3ba0b13d833fdd03ad1f217523a8a2b2527b5507335f71dca1153183d", size = 2503005, upload-time = "2025-12-10T17:54:32.993Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/45/da1a27a6377807ca427cd56534231f0920e1895e16630204f382a0df14c5/grimp-3.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:154e84a2053e9f858ae48743de23a5ad4eb994007518c29371276f59b8419036", size = 2515776, upload-time = "2025-12-10T17:54:47.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/b918a29ce98029cd7a9e33a584be43a93288d5283fb7ccef5b6b2ba39ede/grimp-3.14-cp311-cp311-win32.whl", hash = "sha256:3189c86c3e73016a1907ee3ba9f7a6ca037e3601ad09e60ce9bf12b88877f812", size = 1873189, upload-time = "2025-12-10T17:55:11.872Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d7/2327c203f83a25766fbd62b0df3b24230d422b6e53518ff4d1c5e69793f1/grimp-3.14-cp311-cp311-win_amd64.whl", hash = "sha256:201f46a6a4e5ee9dfba4a2f7d043f7deab080d1d84233f4a1aee812678c25307", size = 2014277, upload-time = "2025-12-10T17:55:04.144Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/a35ff62f35aa5fd148053506eddd7a8f2f6afaed31870dc608dd0eb38e4f/grimp-3.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ffabc6940301214753bad89ec0bfe275892fa1f64b999e9a101f6cebfc777133", size = 2178573, upload-time = "2025-12-10T17:53:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/bd2e80273da4d46110969fc62252e5372e0249feb872bc7fe76fdc7f1818/grimp-3.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:075d9a1c78d607792d0ed8d4d3d7754a621ef04c8a95eaebf634930dc9232bb2", size = 2110452, upload-time = "2025-12-10T17:53:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c3/7307249c657d34dca9d250d73ba027d6cfe15a98fb3119b6e5210bc388b7/grimp-3.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ff52addeb20955a4d6aa097bee910573ffc9ef0d3c8a860844f267ad958156", size = 2283064, upload-time = "2025-12-10T17:52:07.673Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d2/cae4cf32dc8d4188837cc4ab183300d655f898969b0f169e240f3b7c25be/grimp-3.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d10e0663e961fcbe8d0f54608854af31f911f164c96a44112d5173050132701f", size = 2235893, upload-time = "2025-12-10T17:52:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/3f58bc3064fc305dac107d08003ba65713a5bc89a6d327f1c06b30cce752/grimp-3.14-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ab874d7ddddc7a1291259cf7c31a4e7b5c612e9da2e24c67c0eb1a44a624e67", size = 2393376, upload-time = "2025-12-10T17:53:02.397Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b8/f476f30edf114f04cb58e8ae162cb4daf52bda0ab01919f3b5b7edb98430/grimp-3.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54fec672ec83355636a852177f5a470c964bede0f6730f9ba3c7b5c8419c9eab", size = 2571342, upload-time = "2025-12-10T17:52:35.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/2e44d3c4f591f95f86322a8f4dbb5aac17001d49e079f3a80e07e7caaf09/grimp-3.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9e221b5e8070a916c780e88c877fee2a61c95a76a76a2a076396e459511b0bb", size = 2359022, upload-time = "2025-12-10T17:52:49.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/42b4d6bc0ea119ce2e91e1788feabf32c5433e9617dbb495c2a3d0dc7f12/grimp-3.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea6b495f9b4a8d82f5ce544921e76d0d12017f5d1ac3a3bd2f5ac88ab055b1c", size = 2309424, upload-time = "2025-12-10T17:53:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/6a731989625c1790f4da7602dcbf9d6525512264e853cda77b3b3602d5e0/grimp-3.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:655e8d3f79cd99bb859e09c9dd633515150e9d850879ca71417d5ac31809b745", size = 2462754, upload-time = "2025-12-10T17:53:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/3d1571c0a39a59dd68be4835f766da64fe64cbab0d69426210b716a8bdf0/grimp-3.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a14f10b1b71c6c37647a76e6a49c226509648107abc0f48c1e3ecd158ba05531", size = 2501356, upload-time = "2025-12-10T17:54:06.014Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/8950b8229095ebda5c54c8784e4d1f0a6e19423f2847289ef9751f878798/grimp-3.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:81685111ee24d3e25f8ed9e77ed00b92b58b2414e1a1c2937236026900972744", size = 2504631, upload-time = "2025-12-10T17:54:34.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/23bed3da9206138d36d01890b656c7fb7adfb3a37daac8842d84d8777ade/grimp-3.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce8352a8ea0e27b143136ea086582fc6653419aa8a7c15e28ed08c898c42b185", size = 2514751, upload-time = "2025-12-10T17:54:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/6f1f55c97ee982f133ec5ccb22fc99bf5335aee70c208f4fb86cd833b8d5/grimp-3.14-cp312-cp312-win32.whl", hash = "sha256:3fc0f98b3c60d88e9ffa08faff3200f36604930972f8b29155f323b76ea25a06", size = 1875041, upload-time = "2025-12-10T17:55:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/03ba01288e2a41a948bc8526f32c2eeaddd683ed34be1b895e31658d5a4c/grimp-3.14-cp312-cp312-win_amd64.whl", hash = "sha256:6bca77d1d50c8dc402c96af21f4e28e2f1e9938eeabd7417592a22bd83cde3c3", size = 2013868, upload-time = "2025-12-10T17:55:05.907Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/d12a9c821b79ba31fc52243e564712b64140fc6d011c2bdbb483d9092a12/grimp-3.14-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af8a625554beea84530b98cc471902155b5fc042b42dc47ec846fa3e32b0c615", size = 2178632, upload-time = "2025-12-10T17:53:44.55Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8c/d6620dbc245149d5a5a7a9342733556ba91a672f358259c0ab31d889b56b/grimp-3.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0dd1942ffb419ad342f76b0c3d3d2d7f312b264ddc578179d13ce8d5acec1167", size = 2110288, upload-time = "2025-12-10T17:53:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9d/ea51edc4eb295c99786040051c66466bfa235fd1def9f592057b36e03d0f/grimp-3.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537f784ce9b4acf8657f0b9714ab69a6c72ffa752eccc38a5a85506103b1a194", size = 2282197, upload-time = "2025-12-10T17:52:09.304Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6e/7db27818ced6a797f976ca55d981a3af5c12aec6aeda12d63965847cd028/grimp-3.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78ab18c08770aa005bef67b873bc3946d33f65727e9f3e508155093db5fa57d6", size = 2235720, upload-time = "2025-12-10T17:52:21.806Z" },
+    { url = "https://files.pythonhosted.org/packages/37/26/0e3bbae4826bd6eaabf404738400414071e73ddb1e65bf487dcce17858c4/grimp-3.14-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28ca58728c27e7292c99f964e6ece9295c2f9cfdefc37c18dea0679c783ffb6f", size = 2393023, upload-time = "2025-12-10T17:53:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f2/7da91db5703da34c7ef4c7cddcbb1a8fc30cd85fe54756eba942c6fb27d8/grimp-3.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b5577de29c6c5ae6e08d4ca0ac361b45dba323aa145796e6b320a6ea35414b7", size = 2571108, upload-time = "2025-12-10T17:52:36.523Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5e/4d6278f18032c7208696edf8be24a4b5f7fad80acc20ffca737344bcecb5/grimp-3.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d7d1f9f42306f455abcec34db877e4887ff15f2777a43491f7ccbd6936c449b", size = 2358531, upload-time = "2025-12-10T17:52:50.521Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fb/231c32493161ac82f27af6a56965daefa0ec6030fdaf5b948ddd5d68d000/grimp-3.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39bd5c9b7cef59ee30a05535e9cb4cbf45a3c503f22edce34d0aa79362a311a9", size = 2308831, upload-time = "2025-12-10T17:53:12.587Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/f6db325bf5efbbebc9c85cad0af865e821a12a0ba58ee309e938cbd5fedf/grimp-3.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fec3116b4f780a1bc54176b19e6b9f2e36e2ef3164b8fc840660566af35df88", size = 2462138, upload-time = "2025-12-10T17:53:52.403Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/cc3fe29cf07f70364018086840c228a190539ab8105147e34588db590792/grimp-3.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0233a35a5bbb23688d63e1736b54415fa9994ace8dfeb7de8514ed9dee212968", size = 2501393, upload-time = "2025-12-10T17:54:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/eb/54cada9a726455148da23f64577b5cd164164d23a6449e3fa14551157356/grimp-3.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e46b2fef0f1da7e7e2f8129eb93c7e79db716ff7810140a22ce5504e10ed86df", size = 2504514, upload-time = "2025-12-10T17:54:36.34Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/e6afe4f0652df07e8762f61899d1202b73c22c559c804d0a09e5aab2ff17/grimp-3.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3e6d9b50623ee1c3d2a1927ec3f5d408995ea1f92f3e91ed996c908bb40e856f", size = 2514018, upload-time = "2025-12-10T17:54:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/2b8550acc1f010301f02c4fe9664810929fd9277cd032ab608b8534a96fb/grimp-3.14-cp313-cp313-win32.whl", hash = "sha256:fd57c56f5833c99320ec77e8ba5508d56f6fb48ec8032a942f7931cc6ebb80ce", size = 1874922, upload-time = "2025-12-10T17:55:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c7/bc9db5a54ef22972cd17d15ad80a8fee274a471bd3f02300405702d29ea5/grimp-3.14-cp313-cp313-win_amd64.whl", hash = "sha256:173307cf881a126fe5120b7bbec7d54384002e3c83dcd8c4df6ce7f0fee07c53", size = 2013705, upload-time = "2025-12-10T17:55:07.488Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/02710bf5e50997168c84ac622b10dd41d35515efd0c67549945ad20996a0/grimp-3.14-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe29f8f13fbd7c314908ed535183a36e6db71839355b04869b27f23c58fa082", size = 2281868, upload-time = "2025-12-10T17:52:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/2e440c6762cc78bd50582e1b092357d2255f0852ccc6218d8db25170ab31/grimp-3.14-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073d285b00100153fd86064c7726bb1b6d610df1356d33bb42d3fd8809cb6e72", size = 2230917, upload-time = "2025-12-10T17:52:23.212Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bb/2e7dce129b88f07fc525fe5c97f28cfb7ed7b62c59386d39226b4d08969c/grimp-3.14-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6d6efc37e1728bbfcd881b89467be5f7b046292597b3ebe5f8e44e89ea8b6cb", size = 2571371, upload-time = "2025-12-10T17:52:37.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2b/8f1be8294af60c953687db7dec25525d87ed9c2aa26b66dcbe5244abaca2/grimp-3.14-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5337d65d81960b712574c41e85b480d4480bbb5c6f547c94e634f6c60d730889", size = 2356980, upload-time = "2025-12-10T17:52:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ca/ead91e04b3ddd4774ae74601860ea0f0f21bcf6b970b6769ba9571eb2904/grimp-3.14-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:84a7fea63e352b325daa89b0b7297db411b7f0036f8d710c32f8e5090e1fc3ca", size = 2461540, upload-time = "2025-12-10T17:53:53.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/aa/f8a085ff73c37d6e6a37de9f58799a3fea9e16badf267aaef6f11c9a53a3/grimp-3.14-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d0b19a3726377165fe1f7184a8af317734d80d32b371b6c5578747867ab53c0b", size = 2497925, upload-time = "2025-12-10T17:54:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/db3c2d6df07fe74faf5a28fcf3b44fad2831d323ba4a3c2ff66b77a6520c/grimp-3.14-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9caa4991f530750f88474a3f5ecf6ef9f0d064034889d92db00cfb4ecb78aa24", size = 2501794, upload-time = "2025-12-10T17:54:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/095f4e3765e7b60425a41e9fbd2b167f8b0acb957cc88c387f631778a09d/grimp-3.14-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1876efc119b99332a5cc2b08a6bdaada2f0ad94b596f0372a497e2aa8bda4d94", size = 2515203, upload-time = "2025-12-10T17:54:52.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150, upload-time = "2025-12-10T17:53:46.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280, upload-time = "2025-12-10T17:53:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367, upload-time = "2025-12-10T17:52:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125, upload-time = "2025-12-10T17:52:24.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735, upload-time = "2025-12-10T17:53:05.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388, upload-time = "2025-12-10T17:52:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637, upload-time = "2025-12-10T17:52:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335, upload-time = "2025-12-10T17:53:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680, upload-time = "2025-12-10T17:53:55.507Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808, upload-time = "2025-12-10T17:54:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013, upload-time = "2025-12-10T17:54:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043, upload-time = "2025-12-10T17:54:54.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509, upload-time = "2025-12-10T17:55:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364, upload-time = "2025-12-10T17:55:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385, upload-time = "2025-12-10T17:52:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470, upload-time = "2025-12-10T17:52:26.104Z" },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579, upload-time = "2025-12-10T17:52:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545, upload-time = "2025-12-10T17:52:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022, upload-time = "2025-12-10T17:53:56.923Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256, upload-time = "2025-12-10T17:54:27.214Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056, upload-time = "2025-12-10T17:54:41.537Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157, upload-time = "2025-12-10T17:54:55.874Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cc/dbc00210d0324b8fc1242d8e857757c7e0b62ff0fc0c1bc8dcc42342da85/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c8a8aab9b4310a7e69d7d845cac21cf14563aa0520ea322b948eadeae56d303", size = 2284804, upload-time = "2025-12-10T17:52:16.379Z" },
+    { url = "https://files.pythonhosted.org/packages/80/89/851d3d345342e9bcec3fe85d3997db29501fa59f958c1566bf3e24d9d7d9/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d781943b27e5875a41c8f9cfc80f8f0a349f864379192b8c3faa0e6a22593313", size = 2235176, upload-time = "2025-12-10T17:52:30.795Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/5f94702a8d5c121cafcdc9664de34c34f19d0d91a1127bf3946a2631f7a3/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9630d4633607aff94d0ac84b9c64fef1382cdb05b00d9acbde47f8745e264871", size = 2391258, upload-time = "2025-12-10T17:53:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a2/df8c79de5c9e227856d048cc1551c4742a5f97660c40304ac278bd48607f/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7cb00e1bcca583668554a8e9e1e4229a1d11b0620969310aae40148829ff6a32", size = 2571443, upload-time = "2025-12-10T17:52:43.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/21/747b7ed9572bbdc34a76dfec12ce510e80164b1aa06d3b21b34994e5f567/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3389da4ceaaa7f7de24a668c0afc307a9f95997bd90f81ec359a828a9bd1d270", size = 2357767, upload-time = "2025-12-10T17:52:57.84Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e6/485c5e3b64933e71f72f0cc45b0d7130418a6a5a13cedc2e8411bd76f290/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd7a32970ef97e42d4e7369397c7795287d84a736d788ccb90b6c14f0561d975", size = 2309069, upload-time = "2025-12-10T17:53:15.203Z" },
+    { url = "https://files.pythonhosted.org/packages/31/bd/12024a8cba1c77facc1422a7b48cd0d04c252fc9178fd6f99dc05a8af57b/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:fd1278623fa09f62abc0fd8a6500f31b421a1fd479980f44c2926020a0becf02", size = 2466429, upload-time = "2025-12-10T17:54:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7f/0e5977887e1c8f00f84bb4125217534806ffdcef9cf52f3580aa3b151f4b/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:9cfa52c89333d3d8fe9dc782529e888270d060231c3783e036d424044671dde0", size = 2501190, upload-time = "2025-12-10T17:54:30.107Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6b/06acb94b6d0d8c7277bb3e33f93224aa3be5b04643f853479d3bf7b23ace/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:48a5be4a12fca6587e6885b4fc13b9e242ab8bf874519292f0f13814aecf52cc", size = 2503440, upload-time = "2025-12-10T17:54:44.444Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4d/2e531370d12e7a564f67f680234710bbc08554238a54991cd244feb61fb6/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:3fcc332466783a12a42cd317fd344c30fe734ba4fa2362efff132dc3f8d36da7", size = 2516525, upload-time = "2025-12-10T17:54:58.987Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +951,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]
@@ -1594,6 +1710,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pydeps"
+version = "3.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "stdlib-list" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/1b/b5dfc2ed2d5fc4e281b319562bae323c4dbb83dedc91f952e15a565a41c4/pydeps-3.0.6.tar.gz", hash = "sha256:7f8b12c9db90f5a2e009fe0ef75f2945bf698d6cc5fb064423a525823d423085", size = 54777, upload-time = "2026-04-23T10:34:50.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/93/f152a9d5c669efdce1c4e4328256eb2a61486134a2ff4dce8cb93bcd8e9d/pydeps-3.0.6-py3-none-any.whl", hash = "sha256:fc102c0ee2ad25a1596714c7175d8060fa138aaa87eafb308e820e88a709e5fc", size = 48106, upload-time = "2026-04-23T10:34:48.622Z" },
+]
+
+[[package]]
 name = "pydocket"
 version = "0.18.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2268,6 +2396,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "stdlib-list"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/25/f1540879c8815387980e56f973e54605bd924612399ace31487f7444171c/stdlib_list-0.12.0.tar.gz", hash = "sha256:517824f27ee89e591d8ae7c1dd9ff34f672eae50ee886ea31bb8816d77535675", size = 60923, upload-time = "2025-10-24T19:21:22.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/3d/2970b27a11ae17fb2d353e7a179763a2fe6f37d6d2a9f4d40104a2f132e9/stdlib_list-0.12.0-py3-none-any.whl", hash = "sha256:df2d11e97f53812a1756fb5510393a11e3b389ebd9239dc831c7f349957f62f2", size = 87615, upload-time = "2025-10-24T19:21:20.619Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add import-linter contracts for controlplane package boundaries.
- Add grimp-based package coupling report command.
- Document lint-imports, package report, pydeps, and GitNexus usage.

## Test Plan
- uv run lint-imports
- uv run controlplane-package-report
- uv run pytest tests/test_package_layout.py tests/test_import_contracts.py tests/test_package_report.py tests/test_architecture_docs.py -q
- uv run pytest -q