### PR TITLE
Refactor scenario selection resolution

### DIFF
--- a/docs/plans/2026-05-04-package-architecture-checks.md
+++ b/docs/plans/2026-05-04-package-architecture-checks.md
@@ -25,7 +25,7 @@ controlplane_tool.functions       function catalog and control-plane API helpers
 controlplane_tool.infra           VM, runtime, registry, Prometheus, Kubernetes support
 controlplane_tool.loadtest        k6, load-test flow, metrics gate, reports
 controlplane_tool.orchestation    flow catalog, local flow orchestration, Prefect adapters
-controlplane_tool.scenario        scenario models, planner, component library
+controlplane_tool.scenario        scenario models, planner, component library, shared selection resolution
 controlplane_tool.sut             SUT preflight helpers
 controlplane_tool.tui             interactive TUI
 controlplane_tool.workspace       paths, profiles, settings

--- a/docs/plans/2026-05-05-scenario-selection-resolution-refactor.md
+++ b/docs/plans/2026-05-05-scenario-selection-resolution-refactor.md
@@ -1,0 +1,1054 @@
+# Scenario Selection Resolution Refactor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deduplicate scenario/profile/function-selection resolution across the controlplane CLI surfaces without changing CLI/TUI behavior.
+
+**Architecture:** Add a small shared helper module under `controlplane_tool.scenario` for pure selection-resolution primitives: CSV parsing, workspace path resolution, explicit-selection detection, scenario construction from `ScenarioSelectionConfig`, and scenario overlay with runtime/namespace/registry overrides. Keep command-specific request construction in the CLI modules; do not introduce a large generic resolver object in this pass.
+
+**Tech Stack:** Python 3.12, Typer, Pydantic models, pytest, import-linter, GitNexus MCP impact analysis.
+
+---
+
+## Current Duplication
+
+The first refactor target is semantic duplication in these files:
+
+- `tools/controlplane/src/controlplane_tool/cli/e2e_commands.py`
+- `tools/controlplane/src/controlplane_tool/cli/test_commands.py`
+- `tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py`
+
+Repeated responsibilities:
+
+- parse comma-separated function selections
+- resolve optional scenario-file paths relative to the workspace
+- detect explicit function/scenario selection
+- build a `ResolvedScenario` from `ScenarioSelectionConfig`
+- reload a manifest while preserving selected functions but overriding runtime/namespace/registry
+- derive a stable source label for resolved scenarios
+
+Do not move VM request creation, Typer command registration, output rendering, or scenario-specific validation into the shared module. Those are command-surface responsibilities.
+
+## Safety Requirements
+
+- Before editing any existing function/class, run GitNexus impact analysis for that symbol and record risk in the implementation notes.
+- If GitNexus reports HIGH or CRITICAL risk, stop and report the affected direct callers before editing.
+- Use TDD for each new helper and each migration checkpoint.
+- Keep commits small and reversible.
+- Run `uv run lint-imports` after each migration task that changes imports.
+
+---
+
+### Task 0: Set Up Isolated Worktree and Baseline
+
+**Files:**
+- No code changes.
+
+**Step 1: Create a feature worktree**
+
+Run from repository root:
+
+```bash
+git fetch origin main
+git worktree add .worktrees/scenario-selection-resolution-refactor -b codex/scenario-selection-resolution-refactor origin/main
+cd .worktrees/scenario-selection-resolution-refactor/tools/controlplane
+```
+
+Expected:
+
+```text
+Preparing worktree ...
+HEAD is now at ...
+```
+
+**Step 2: Run baseline architecture checks**
+
+Run:
+
+```bash
+uv run lint-imports
+uv run pytest tests/test_package_layout.py tests/test_import_contracts.py tests/test_package_report.py -q
+```
+
+Expected:
+
+```text
+Contracts: 4 kept, 0 broken.
+... passed
+```
+
+**Step 3: Run focused baseline tests for the target surfaces**
+
+Run:
+
+```bash
+uv run pytest tests/test_e2e_commands.py tests/test_cli_test_commands.py tests/test_loadtest_commands.py -q
+```
+
+Expected: all tests pass before refactoring.
+
+---
+
+### Task 1: Add Shared Scenario Selection Helper Module
+
+**Files:**
+- Create: `tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py`
+- Create: `tools/controlplane/tests/test_selection_resolution.py`
+
+**Step 1: Run GitNexus impact analysis before introducing the shared module**
+
+Run through MCP:
+
+```text
+gitnexus_impact({target: "resolve_scenario_spec", direction: "upstream", includeTests: true, maxDepth: 2})
+gitnexus_impact({target: "overlay_scenario_selection", direction: "upstream", includeTests: true, maxDepth: 2})
+```
+
+Expected: note risk and direct callers. This task adds wrapper helpers around these functions; it should not change existing behavior.
+
+**Step 2: Write failing tests**
+
+Create `tools/controlplane/tests/test_selection_resolution.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from controlplane_tool.core.models import ScenarioSelectionConfig
+from controlplane_tool.scenario.scenario_loader import resolve_scenario_spec
+from controlplane_tool.scenario.scenario_models import ScenarioSpec
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    explicit_selection_requested,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
+)
+
+
+def test_parse_function_csv_trims_empty_items() -> None:
+    assert parse_function_csv(" word-stats-java, ,json-transform-java ") == [
+        "word-stats-java",
+        "json-transform-java",
+    ]
+
+
+def test_configured_scenario_path_resolves_workspace_relative_path() -> None:
+    result = configured_scenario_path("tools/controlplane/scenarios/k8s-demo-java.toml")
+
+    assert result is not None
+    assert result.is_absolute()
+    assert result.name == "k8s-demo-java.toml"
+
+
+def test_configured_scenario_path_keeps_none_empty() -> None:
+    assert configured_scenario_path(None) is None
+    assert configured_scenario_path("") is None
+
+
+def test_explicit_selection_requested_detects_preset_functions_or_file() -> None:
+    assert explicit_selection_requested(
+        function_preset="demo-java",
+        functions=[],
+        scenario_file=None,
+    )
+    assert explicit_selection_requested(
+        function_preset=None,
+        functions=["word-stats-java"],
+        scenario_file=None,
+    )
+    assert explicit_selection_requested(
+        function_preset=None,
+        functions=[],
+        scenario_file=Path("scenario.toml"),
+    )
+    assert not explicit_selection_requested(
+        function_preset=None,
+        functions=[],
+        scenario_file=None,
+    )
+
+
+def test_resolved_scenario_from_config_uses_default_base_scenario() -> None:
+    scenario = resolved_scenario_from_config(
+        ScenarioSelectionConfig(function_preset="demo-java"),
+        name="cli-test-selection",
+        base_scenario="k3s-junit-curl",
+        runtime="java",
+        namespace="demo",
+        local_registry="localhost:5000",
+    )
+
+    assert scenario.name == "cli-test-selection"
+    assert scenario.base_scenario == "k3s-junit-curl"
+    assert scenario.runtime == "java"
+    assert scenario.namespace == "demo"
+    assert scenario.local_registry == "localhost:5000"
+    assert scenario.function_preset == "demo-java"
+
+
+def test_overlay_selected_scenario_preserves_manifest_functions_with_overrides() -> None:
+    original = resolve_scenario_spec(
+        ScenarioSpec(
+            name="manifest",
+            base_scenario="k3s-junit-curl",
+            runtime="java",
+            functions=["word-stats-java"],
+            namespace="original",
+            local_registry="registry:5000",
+        )
+    )
+
+    updated = overlay_selected_scenario(
+        original,
+        base_scenario="cli-stack",
+        runtime="python",
+        namespace="override",
+        local_registry="localhost:5001",
+    )
+
+    assert updated.base_scenario == "cli-stack"
+    assert updated.runtime == "python"
+    assert updated.namespace == "override"
+    assert updated.local_registry == "localhost:5001"
+    assert updated.function_keys == ["word-stats-java"]
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_selection_resolution.py -q
+```
+
+Expected:
+
+```text
+ModuleNotFoundError: No module named 'controlplane_tool.scenario.selection_resolution'
+```
+
+**Step 4: Add minimal implementation**
+
+Create `tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.core.models import ScenarioSelectionConfig
+from controlplane_tool.scenario.scenario_loader import (
+    overlay_scenario_selection,
+    resolve_scenario_spec,
+)
+from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
+from controlplane_tool.workspace.paths import resolve_workspace_path
+
+
+def parse_function_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def configured_scenario_path(path: str | Path | None) -> Path | None:
+    if path is None:
+        return None
+    text = str(path).strip()
+    if not text:
+        return None
+    return resolve_workspace_path(Path(text))
+
+
+def explicit_selection_requested(
+    *,
+    function_preset: str | None,
+    functions: list[str],
+    scenario_file: Path | None,
+) -> bool:
+    return bool(function_preset or functions or scenario_file is not None)
+
+
+def resolved_scenario_from_config(
+    config: ScenarioSelectionConfig,
+    *,
+    name: str,
+    base_scenario: str,
+    runtime: str,
+    namespace: str | None,
+    local_registry: str,
+) -> ResolvedScenario:
+    return resolve_scenario_spec(
+        ScenarioSpec(
+            name=name,
+            base_scenario=config.base_scenario or base_scenario,
+            runtime=runtime,
+            function_preset=config.function_preset,
+            functions=list(config.functions),
+            namespace=namespace if namespace is not None else config.namespace,
+            local_registry=local_registry or config.local_registry,
+        )
+    )
+
+
+def overlay_selected_scenario(
+    scenario: ResolvedScenario,
+    *,
+    base_scenario: str | None = None,
+    runtime: str,
+    namespace: str | None,
+    local_registry: str,
+) -> ResolvedScenario:
+    source = (
+        scenario.model_copy(update={"base_scenario": base_scenario})
+        if base_scenario is not None
+        else scenario
+    )
+    return overlay_scenario_selection(
+        source,
+        function_preset=scenario.function_preset,
+        functions=[] if scenario.function_preset else list(scenario.function_keys),
+        runtime=runtime,
+        namespace=namespace,
+        local_registry=local_registry,
+    )
+```
+
+**Step 5: Run helper tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_selection_resolution.py -q
+```
+
+Expected:
+
+```text
+6 passed
+```
+
+**Step 6: Commit**
+
+Run:
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py tools/controlplane/tests/test_selection_resolution.py
+git commit -m "Add shared scenario selection helpers"
+```
+
+---
+
+### Task 2: Migrate E2E CLI Resolution to Shared Helpers
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/cli/e2e_commands.py`
+- Test: `tools/controlplane/tests/test_e2e_commands.py`
+- Test: `tools/controlplane/tests/test_selection_resolution.py`
+
+**Step 1: Run GitNexus impact analysis**
+
+Run through MCP:
+
+```text
+gitnexus_impact({target: "_resolve_run_request", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/e2e_commands.py"})
+gitnexus_impact({target: "_parse_csv", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/e2e_commands.py"})
+gitnexus_impact({target: "_configured_scenario_path", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/e2e_commands.py"})
+gitnexus_impact({target: "_resolved_from_config", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/e2e_commands.py"})
+gitnexus_impact({target: "_reload_with_overrides", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/e2e_commands.py"})
+```
+
+Expected: `_resolve_run_request` will likely be MEDIUM/HIGH because CLI tests cover it. Review direct callers before editing.
+
+**Step 2: Add a regression test that exercises the migrated path**
+
+If not already present, add this to `tools/controlplane/tests/test_e2e_commands.py`:
+
+```python
+def test_e2e_request_applies_cli_override_to_saved_profile_scenario_file(tmp_path: Path) -> None:
+    from controlplane_tool.cli import e2e_commands
+    from controlplane_tool.core.models import Profile, ScenarioSelectionConfig
+    from controlplane_tool.workspace.profiles import save_profile
+
+    scenario_file = tmp_path / "scenario.toml"
+    scenario_file.write_text(
+        """
+name = "custom"
+base_scenario = "k3s-junit-curl"
+runtime = "java"
+function_preset = "demo-java"
+namespace = "from-file"
+local_registry = "registry:5000"
+""",
+        encoding="utf-8",
+    )
+    profile = Profile(
+        name="saved",
+        scenario=ScenarioSelectionConfig(scenario_file=str(scenario_file)),
+    )
+    save_profile(profile, root=tmp_path)
+
+    request = e2e_commands._resolve_run_request(
+        scenario=None,
+        runtime="python",
+        lifecycle="external",
+        name=None,
+        host="127.0.0.1",
+        user="ubuntu",
+        home=None,
+        cpus=2,
+        memory="2G",
+        disk="10G",
+        cleanup_vm=True,
+        namespace="override",
+        local_registry="localhost:5001",
+        function_preset="metrics-smoke",
+        functions_csv=None,
+        scenario_file=None,
+        saved_profile="saved",
+    )
+
+    assert request.resolved_scenario is not None
+    assert request.resolved_scenario.runtime == "python"
+    assert request.resolved_scenario.namespace == "override"
+    assert request.resolved_scenario.local_registry == "localhost:5001"
+    assert request.resolved_scenario.function_preset == "metrics-smoke"
+```
+
+If this exact setup conflicts with existing profile directory behavior, use `monkeypatch` to point `controlplane_tool.workspace.profiles.profiles_dir` at `tmp_path`, matching existing local test patterns.
+
+**Step 3: Run the regression test before implementation**
+
+Run:
+
+```bash
+uv run pytest tests/test_e2e_commands.py::test_e2e_request_applies_cli_override_to_saved_profile_scenario_file -q
+```
+
+Expected: pass if behavior already exists. This is acceptable for migration work; it protects behavior before moving code.
+
+**Step 4: Replace local helper implementations with imports**
+
+Modify `tools/controlplane/src/controlplane_tool/cli/e2e_commands.py`.
+
+Remove imports no longer needed:
+
+```python
+from controlplane_tool.workspace.paths import default_tool_paths, resolve_workspace_path
+from controlplane_tool.scenario.scenario_loader import (
+    load_scenario_file,
+    overlay_scenario_selection,
+    resolve_scenario_spec,
+)
+from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
+```
+
+Keep `resolve_workspace_path` only if another function still uses it outside migrated helpers.
+
+Add:
+
+```python
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
+)
+```
+
+Then update local calls:
+
+```python
+explicit_functions = parse_function_csv(functions_csv)
+```
+
+```python
+profile_file_scenario = (
+    load_scenario_file(configured_scenario_path(profile_selection.scenario_file))
+    if configured_scenario_path(profile_selection.scenario_file) is not None
+    else None
+)
+```
+
+Replace `_resolved_from_config(...)` with:
+
+```python
+resolved_scenario_from_config(
+    ScenarioSelectionConfig(...),
+    name=f"{effective_scenario}-cli",
+    base_scenario=effective_scenario,
+    runtime=effective_runtime,
+    namespace=effective_namespace,
+    local_registry=effective_registry,
+)
+```
+
+Replace `_reload_with_overrides(...)` with:
+
+```python
+overlay_selected_scenario(
+    profile_file_scenario,
+    base_scenario=effective_scenario,
+    runtime=effective_runtime,
+    namespace=effective_namespace,
+    local_registry=effective_registry,
+)
+```
+
+Delete the local functions:
+
+```python
+def _parse_csv(...)
+def _configured_scenario_path(...)
+def _resolved_from_config(...)
+def _reload_with_overrides(...)
+```
+
+**Step 5: Run E2E CLI tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_e2e_commands.py tests/test_selection_resolution.py -q
+uv run lint-imports
+```
+
+Expected:
+
+```text
+... passed
+Contracts: 4 kept, 0 broken.
+```
+
+**Step 6: Commit**
+
+Run:
+
+```bash
+git add tools/controlplane/src/controlplane_tool/cli/e2e_commands.py tools/controlplane/tests/test_e2e_commands.py
+git commit -m "Reuse shared selection helpers in e2e CLI"
+```
+
+---
+
+### Task 3: Migrate CLI-Test Resolution to Shared Helpers
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/cli/test_commands.py`
+- Test: `tools/controlplane/tests/test_cli_test_commands.py`
+- Test: `tools/controlplane/tests/test_selection_resolution.py`
+
+**Step 1: Run GitNexus impact analysis**
+
+Run through MCP:
+
+```text
+gitnexus_impact({target: "_resolve_run_request", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/test_commands.py"})
+gitnexus_impact({target: "_parse_csv", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/test_commands.py"})
+gitnexus_impact({target: "_configured_scenario_path", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/test_commands.py"})
+gitnexus_impact({target: "_resolved_from_config", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/test_commands.py"})
+gitnexus_impact({target: "_reload_with_overrides", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/test_commands.py"})
+```
+
+Expected: review direct callers. This is command-resolution code and should have direct test coverage.
+
+**Step 2: Add a regression test for function-selection rejection**
+
+If not already covered, add this to `tools/controlplane/tests/test_cli_test_commands.py`:
+
+```python
+def test_cli_test_rejects_function_selection_for_nonselectable_scenario() -> None:
+    import pytest
+    from controlplane_tool.cli.test_commands import _resolve_run_request
+
+    with pytest.raises(ValueError, match="does not accept function selection"):
+        _resolve_run_request(
+            scenario="vm",
+            runtime="java",
+            lifecycle="external",
+            name=None,
+            host="127.0.0.1",
+            user="ubuntu",
+            home=None,
+            cpus=2,
+            memory="2G",
+            disk="10G",
+            keep_vm=True,
+            namespace=None,
+            local_registry=None,
+            function_preset="demo-java",
+            functions_csv=None,
+            scenario_file=None,
+            saved_profile=None,
+        )
+```
+
+**Step 3: Run the regression test**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_test_commands.py::test_cli_test_rejects_function_selection_for_nonselectable_scenario -q
+```
+
+Expected: pass before migration if behavior already exists.
+
+**Step 4: Replace local helper implementations with shared helpers**
+
+Modify `tools/controlplane/src/controlplane_tool/cli/test_commands.py`.
+
+Add:
+
+```python
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    explicit_selection_requested,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
+)
+```
+
+Update:
+
+```python
+explicit_functions = parse_function_csv(functions_csv)
+```
+
+Replace `_has_explicit_selection(...)` with:
+
+```python
+explicit_selection_requested(
+    function_preset=function_preset,
+    functions=explicit_functions,
+    scenario_file=explicit_file_path,
+)
+```
+
+Replace `_resolved_from_config(...)` with `resolved_scenario_from_config(...)`.
+
+Replace `_reload_with_overrides(...)` with:
+
+```python
+overlay_selected_scenario(
+    explicit_file_scenario,
+    runtime=effective_runtime,
+    namespace=effective_namespace,
+    local_registry=effective_registry,
+)
+```
+
+Delete the local helpers now covered by shared functions:
+
+```python
+def _parse_csv(...)
+def _configured_scenario_path(...)
+def _resolved_from_config(...)
+def _reload_with_overrides(...)
+def _has_explicit_selection(...)
+```
+
+Keep `_load_profile_or_raise` and `_load_scenario_or_raise` local for now because they format command-specific error messages.
+
+**Step 5: Run CLI-test tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_cli_test_commands.py tests/test_selection_resolution.py -q
+uv run lint-imports
+```
+
+Expected:
+
+```text
+... passed
+Contracts: 4 kept, 0 broken.
+```
+
+**Step 6: Commit**
+
+Run:
+
+```bash
+git add tools/controlplane/src/controlplane_tool/cli/test_commands.py tools/controlplane/tests/test_cli_test_commands.py
+git commit -m "Reuse shared selection helpers in cli-test commands"
+```
+
+---
+
+### Task 4: Migrate Loadtest Scenario Path Resolution
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py`
+- Test: `tools/controlplane/tests/test_loadtest_commands.py`
+- Test: `tools/controlplane/tests/test_selection_resolution.py`
+
+**Step 1: Run GitNexus impact analysis**
+
+Run through MCP:
+
+```text
+gitnexus_impact({target: "build_loadtest_request", direction: "upstream", includeTests: true, maxDepth: 2})
+gitnexus_impact({target: "_resolve_scenario", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py"})
+gitnexus_impact({target: "_configured_scenario_path", direction: "upstream", includeTests: true, maxDepth: 2, file_path: "tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py"})
+```
+
+Expected: `build_loadtest_request` is likely MEDIUM because it is used by command tests and TUI/loadtest paths. Review d=1 callers.
+
+**Step 2: Add regression test for scenario-file precedence**
+
+If not already covered, add this to `tools/controlplane/tests/test_loadtest_commands.py`:
+
+```python
+def test_loadtest_request_cli_scenario_file_overrides_profile_scenario_file(tmp_path: Path) -> None:
+    from controlplane_tool.cli.loadtest_commands import build_loadtest_request
+    from controlplane_tool.core.models import Profile, ScenarioSelectionConfig
+
+    profile_scenario = tmp_path / "profile.toml"
+    profile_scenario.write_text(
+        """
+name = "profile-scenario"
+base_scenario = "k3s-junit-curl"
+runtime = "java"
+function_preset = "demo-java"
+""",
+        encoding="utf-8",
+    )
+    cli_scenario = tmp_path / "cli.toml"
+    cli_scenario.write_text(
+        """
+name = "cli-scenario"
+base_scenario = "k3s-junit-curl"
+runtime = "java"
+function_preset = "metrics-smoke"
+""",
+        encoding="utf-8",
+    )
+
+    request = build_loadtest_request(
+        profile=Profile(
+            name="profile",
+            scenario=ScenarioSelectionConfig(scenario_file=str(profile_scenario)),
+        ),
+        scenario_file=cli_scenario,
+    )
+
+    assert request.scenario.name == "cli-scenario"
+    assert request.scenario.function_preset == "metrics-smoke"
+```
+
+**Step 3: Run regression test**
+
+Run:
+
+```bash
+uv run pytest tests/test_loadtest_commands.py::test_loadtest_request_cli_scenario_file_overrides_profile_scenario_file -q
+```
+
+Expected: pass before migration if behavior already exists.
+
+**Step 4: Replace path helper**
+
+Modify `tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py`.
+
+Add:
+
+```python
+from controlplane_tool.scenario.selection_resolution import configured_scenario_path
+```
+
+Delete local:
+
+```python
+def _configured_scenario_path(...)
+```
+
+Replace calls:
+
+```python
+configured_loadtest_scenario = configured_scenario_path(profile.loadtest.scenario_file)
+configured_profile_scenario = configured_scenario_path(profile.scenario.scenario_file)
+```
+
+Keep `_scenario_selection_for`, `_default_profile_for_scenario`, `_resolve_scenario`, and `build_loadtest_request` in this file. They are loadtest-specific and should not be generalized in this pass.
+
+**Step 5: Run loadtest command tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_loadtest_commands.py tests/test_selection_resolution.py -q
+uv run lint-imports
+```
+
+Expected:
+
+```text
+... passed
+Contracts: 4 kept, 0 broken.
+```
+
+**Step 6: Commit**
+
+Run:
+
+```bash
+git add tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py tools/controlplane/tests/test_loadtest_commands.py
+git commit -m "Reuse shared selection path resolution in loadtest commands"
+```
+
+---
+
+### Task 5: Remove Residual Duplicate Helpers and Verify Imports
+
+**Files:**
+- Modify if needed: `tools/controlplane/src/controlplane_tool/cli/e2e_commands.py`
+- Modify if needed: `tools/controlplane/src/controlplane_tool/cli/test_commands.py`
+- Modify if needed: `tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py`
+
+**Step 1: Search for duplicate helper names**
+
+Run:
+
+```bash
+rg -n "def (_parse_csv|_configured_scenario_path|_resolved_from_config|_reload_with_overrides|_has_explicit_selection)" tools/controlplane/src/controlplane_tool/cli
+```
+
+Expected:
+
+```text
+no output
+```
+
+If output remains, inspect whether it is truly duplicate. Remove only helpers covered by `controlplane_tool.scenario.selection_resolution`.
+
+**Step 2: Search for direct duplicated path logic**
+
+Run:
+
+```bash
+rg -n "resolve_workspace_path\\(Path\\(|split\\(\",\"\\)|overlay_scenario_selection\\(" tools/controlplane/src/controlplane_tool/cli
+```
+
+Expected: no duplicated scenario-selection utility logic in the three target command files. Legitimate command-specific uses may remain; inspect before editing.
+
+**Step 3: Run focused checks**
+
+Run:
+
+```bash
+uv run pytest tests/test_selection_resolution.py tests/test_e2e_commands.py tests/test_cli_test_commands.py tests/test_loadtest_commands.py -q
+uv run lint-imports
+```
+
+Expected:
+
+```text
+... passed
+Contracts: 4 kept, 0 broken.
+```
+
+**Step 4: Commit any cleanup**
+
+If Step 1 or Step 2 required edits:
+
+```bash
+git add tools/controlplane/src/controlplane_tool/cli
+git commit -m "Remove duplicate CLI selection helpers"
+```
+
+If no edits were required, skip this commit.
+
+---
+
+### Task 6: Document the Shared Selection Resolution Boundary
+
+**Files:**
+- Modify: `tools/controlplane/README.md`
+- Modify: `docs/plans/2026-05-04-package-architecture-checks.md`
+- Test: `tools/controlplane/tests/test_architecture_docs.py`
+
+**Step 1: Write failing documentation assertion**
+
+Modify `tools/controlplane/tests/test_architecture_docs.py`:
+
+```python
+def test_tool_readme_documents_shared_selection_resolution_boundary() -> None:
+    readme = resolve_workspace_path(Path("tools/controlplane/README.md")).read_text(
+        encoding="utf-8"
+    )
+
+    assert "controlplane_tool.scenario.selection_resolution" in readme
+    assert "scenario/profile selection precedence" in readme
+```
+
+**Step 2: Run doc test and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_architecture_docs.py::test_tool_readme_documents_shared_selection_resolution_boundary -q
+```
+
+Expected:
+
+```text
+FAILED ... AssertionError
+```
+
+**Step 3: Update README**
+
+Append a short paragraph under `## Package architecture checks` in `tools/controlplane/README.md`:
+
+```markdown
+`controlplane_tool.scenario.selection_resolution` owns shared scenario/profile
+selection precedence helpers used by CLI command surfaces. Command modules should
+keep Typer options, error rendering, and request construction local, but should not
+reimplement CSV parsing, workspace scenario path resolution, or manifest overlay
+helpers.
+```
+
+**Step 4: Update package plan document**
+
+In `docs/plans/2026-05-04-package-architecture-checks.md`, update the scenario package description:
+
+```text
+controlplane_tool.scenario        scenario models, planner, component library, shared selection-resolution helpers
+```
+
+**Step 5: Run doc test**
+
+Run:
+
+```bash
+uv run pytest tests/test_architecture_docs.py -q
+```
+
+Expected:
+
+```text
+... passed
+```
+
+**Step 6: Commit**
+
+Run:
+
+```bash
+git add tools/controlplane/README.md tools/controlplane/tests/test_architecture_docs.py docs/plans/2026-05-04-package-architecture-checks.md
+git commit -m "Document shared scenario selection boundary"
+```
+
+---
+
+### Task 7: Final Verification, GitNexus Detection, Push
+
+**Files:**
+- No intended code changes unless verification exposes a narrow fix.
+
+**Step 1: Run package report**
+
+Run:
+
+```bash
+cd tools/controlplane
+uv run controlplane-package-report
+```
+
+Expected: report prints a table. Do not assert exact numbers, but inspect that `controlplane_tool.scenario` outgoing/incoming changes are plausible and `core`, `workflow`, `workspace`, and `app` boundaries remain coherent.
+
+**Step 2: Run import contracts**
+
+Run:
+
+```bash
+uv run lint-imports
+```
+
+Expected:
+
+```text
+Contracts: 4 kept, 0 broken.
+```
+
+**Step 3: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_selection_resolution.py tests/test_e2e_commands.py tests/test_cli_test_commands.py tests/test_loadtest_commands.py tests/test_architecture_docs.py -q
+```
+
+Expected: all pass.
+
+**Step 4: Run full controlplane suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: all pass. Current recent baseline is `868 passed`; exact count may increase after new tests.
+
+**Step 5: Run GitNexus staged/compare detection**
+
+Run through MCP:
+
+```text
+gitnexus_detect_changes({scope: "compare", base_ref: "main"})
+```
+
+Expected: no HIGH/CRITICAL unexpected affected flows. If GitNexus reports broad impact, inspect direct changed symbols and confirm it matches the planned CLI scenario-resolution refactor.
+
+**Step 6: Update GitNexus index after final commit**
+
+Run:
+
+```bash
+npx gitnexus analyze
+```
+
+Expected: repository indexed successfully or already up to date.
+
+If `npx gitnexus analyze` edits `AGENTS.md` or `CLAUDE.md` only to rewrite the worktree repo name, restore those generated docs before push:
+
+```bash
+git restore AGENTS.md CLAUDE.md
+```
+
+**Step 7: Push branch**
+
+Run:
+
+```bash
+git push -u origin codex/scenario-selection-resolution-refactor
+```
+
+Expected: branch is pushed and GitHub prints a PR creation URL.
+
+---
+
+## Completion Checklist
+
+- Shared helper module exists at `controlplane_tool.scenario.selection_resolution`.
+- `e2e_commands.py`, `test_commands.py`, and `loadtest_commands.py` no longer duplicate `_configured_scenario_path`.
+- `e2e_commands.py` and `test_commands.py` no longer duplicate CSV parsing or scenario overlay helpers.
+- Command-specific validation and Typer rendering remain in command modules.
+- `uv run lint-imports` passes.
+- Focused tests for selection resolution, E2E commands, CLI-test commands, and loadtest commands pass.
+- Full `uv run pytest -q` passes.
+- GitNexus impact was run before each existing-symbol edit.
+- GitNexus detect changes was reviewed before final push.
+
+## Non-Goals
+
+- Do not refactor TUI selection in this pass.
+- Do not create an abstract base class for CLI command handlers.
+- Do not change CLI option names, output wording, or exit codes except where an existing test already defines the behavior.
+- Do not move loadtest-specific profile construction out of `cli/loadtest_commands.py`.

--- a/tools/controlplane/README.md
+++ b/tools/controlplane/README.md
@@ -128,6 +128,15 @@ Selection precedence is:
 
 When a CLI override is combined with `--scenario-file` or `--saved-profile`, the tool preserves the base scenario metadata (`invoke`, payload mapping, namespace, and `load.profile`) and narrows `load.targets` and payloads to the selected subset instead of rebuilding the scenario from scratch.
 
+`controlplane_tool.scenario.selection_resolution` owns shared scenario/profile
+selection primitives used by CLI surfaces: CSV parsing, workspace-relative
+scenario paths, explicit selection detection, construction from
+`ScenarioSelectionConfig`, and overlaying runtime/namespace/registry or
+function-selection overrides onto an existing scenario. Command modules keep
+request construction, validation, and rendering local to their command surface.
+Use `controlplane_tool.scenario.scenario_loader` directly only for lower-level
+scenario manifest loading and raw scenario overlay operations.
+
 Loadtest saved profiles can also persist:
 
 - `loadtest.default_load_profile`

--- a/tools/controlplane/src/controlplane_tool/cli/e2e_commands.py
+++ b/tools/controlplane/src/controlplane_tool/cli/e2e_commands.py
@@ -11,15 +11,17 @@ from controlplane_tool.e2e.e2e_runner import E2eRunner, ScenarioPlan
 from controlplane_tool.orchestation.flow_catalog import resolve_flow_definition, resolve_flow_task_ids
 from controlplane_tool.functions.catalog import function_runtime_allowlist_for_scenario
 from controlplane_tool.core.models import ScenarioSelectionConfig
-from controlplane_tool.workspace.paths import default_tool_paths, resolve_workspace_path
+from controlplane_tool.workspace.paths import default_tool_paths
 from controlplane_tool.orchestation.prefect_runtime import run_local_flow
 from controlplane_tool.workspace.profiles import load_profile
-from controlplane_tool.scenario.scenario_loader import (
-    load_scenario_file,
-    overlay_scenario_selection,
-    resolve_scenario_spec,
+from controlplane_tool.scenario.scenario_loader import load_scenario_file
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
 )
-from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
+from controlplane_tool.scenario.scenario_models import ResolvedScenario
 from controlplane_tool.infra.vm.vm_models import VmRequest
 
 E2E_CONTEXT_SETTINGS = {
@@ -110,12 +112,6 @@ def _build_request(
     )
 
 
-def _parse_csv(value: str | None) -> list[str]:
-    if not value:
-        return []
-    return [item.strip() for item in value.split(",") if item.strip()]
-
-
 def _render_plan(plan: ScenarioPlan, *, flow_task_ids: list[str] | None = None) -> None:
     def _display_command(command: list[str]) -> str:
         rendered = " ".join(command)
@@ -171,52 +167,6 @@ def _default_selection_for(scenario: str) -> ScenarioSelectionConfig:
     return ScenarioSelectionConfig(base_scenario=scenario, function_preset="demo-java")
 
 
-def _configured_scenario_path(path: str | None) -> Path | None:
-    if not path:
-        return None
-    return resolve_workspace_path(Path(path))
-
-
-def _resolved_from_config(
-    config: ScenarioSelectionConfig,
-    *,
-    name: str,
-    scenario: str,
-    runtime: str,
-    namespace: str | None,
-    local_registry: str,
-) -> ResolvedScenario:
-    return resolve_scenario_spec(
-        ScenarioSpec(
-            name=name,
-            base_scenario=scenario,
-            runtime=runtime,
-            function_preset=config.function_preset,
-            functions=list(config.functions),
-            namespace=namespace if namespace is not None else config.namespace,
-            local_registry=local_registry or config.local_registry,
-        )
-    )
-
-
-def _reload_with_overrides(
-    scenario: ResolvedScenario,
-    *,
-    base_scenario: str,
-    runtime: str,
-    namespace: str | None,
-    local_registry: str,
-) -> ResolvedScenario:
-    return overlay_scenario_selection(
-        scenario.model_copy(update={"base_scenario": base_scenario}),
-        function_preset=scenario.function_preset,
-        functions=[] if scenario.function_preset else list(scenario.function_keys),
-        runtime=runtime,
-        namespace=namespace,
-        local_registry=local_registry,
-    )
-
-
 def _validate_scenario_function_selection(scenario: ResolvedScenario) -> None:
     allowed_runtimes = function_runtime_allowlist_for_scenario(scenario.base_scenario)
     if allowed_runtimes is None:
@@ -268,7 +218,7 @@ def _resolve_run_request(
     scenario_file: Path | None,
     saved_profile: str | None,
 ) -> E2eRequest:
-    explicit_functions = _parse_csv(functions_csv)
+    explicit_functions = parse_function_csv(functions_csv)
     if function_preset and explicit_functions:
         raise ValueError("function selection must use only one of --function-preset or --functions")
 
@@ -277,12 +227,12 @@ def _resolve_run_request(
     profile_runtime = profile.control_plane.implementation if profile is not None else None
 
     profile_file_scenario = (
-        load_scenario_file(_configured_scenario_path(profile_selection.scenario_file))
-        if _configured_scenario_path(profile_selection.scenario_file) is not None
+        load_scenario_file(configured_scenario_path(profile_selection.scenario_file))
+        if configured_scenario_path(profile_selection.scenario_file) is not None
         else None
     )
     explicit_file_scenario = (
-        load_scenario_file(resolve_workspace_path(scenario_file))
+        load_scenario_file(configured_scenario_path(scenario_file))
         if scenario_file is not None
         else None
     )
@@ -320,15 +270,16 @@ def _resolve_run_request(
     resolved_scenario: ResolvedScenario
     scenario_source: str
     request_scenario_file = (
-        resolve_workspace_path(scenario_file)
+        configured_scenario_path(scenario_file)
         if scenario_file is not None
         else None
     )
 
     if function_preset or explicit_functions:
         if explicit_file_scenario is not None:
-            resolved_scenario = overlay_scenario_selection(
-                explicit_file_scenario.model_copy(update={"base_scenario": effective_scenario}),
+            resolved_scenario = overlay_selected_scenario(
+                explicit_file_scenario,
+                base_scenario=effective_scenario,
                 function_preset=function_preset,
                 functions=explicit_functions,
                 runtime=effective_runtime,
@@ -337,8 +288,9 @@ def _resolve_run_request(
             )
             scenario_source = "scenario file + CLI override"
         elif profile_file_scenario is not None:
-            resolved_scenario = overlay_scenario_selection(
-                profile_file_scenario.model_copy(update={"base_scenario": effective_scenario}),
+            resolved_scenario = overlay_selected_scenario(
+                profile_file_scenario,
+                base_scenario=effective_scenario,
                 function_preset=function_preset,
                 functions=explicit_functions,
                 runtime=effective_runtime,
@@ -346,9 +298,9 @@ def _resolve_run_request(
                 local_registry=effective_registry,
             )
             scenario_source = f"saved profile: {saved_profile} + CLI override"
-            request_scenario_file = _configured_scenario_path(profile_selection.scenario_file)
+            request_scenario_file = configured_scenario_path(profile_selection.scenario_file)
         else:
-            resolved_scenario = _resolved_from_config(
+            resolved_scenario = resolved_scenario_from_config(
                 ScenarioSelectionConfig(
                     base_scenario=effective_scenario,
                     function_preset=function_preset,
@@ -357,14 +309,14 @@ def _resolve_run_request(
                     local_registry=effective_registry,
                 ),
                 name=f"{effective_scenario}-cli",
-                scenario=effective_scenario,
+                base_scenario=effective_scenario,
                 runtime=effective_runtime,
                 namespace=effective_namespace,
                 local_registry=effective_registry,
             )
             scenario_source = "explicit CLI override"
     elif explicit_file_scenario is not None:
-        resolved_scenario = _reload_with_overrides(
+        resolved_scenario = overlay_selected_scenario(
             explicit_file_scenario,
             base_scenario=effective_scenario,
             runtime=effective_runtime,
@@ -373,7 +325,7 @@ def _resolve_run_request(
         )
         scenario_source = f"scenario file: {explicit_file_scenario.source_path}"
     elif profile_file_scenario is not None:
-        resolved_scenario = _reload_with_overrides(
+        resolved_scenario = overlay_selected_scenario(
             profile_file_scenario,
             base_scenario=effective_scenario,
             runtime=effective_runtime,
@@ -381,12 +333,12 @@ def _resolve_run_request(
             local_registry=effective_registry,
         )
         scenario_source = f"saved profile: {saved_profile}"
-        request_scenario_file = _configured_scenario_path(profile_selection.scenario_file)
+        request_scenario_file = configured_scenario_path(profile_selection.scenario_file)
     elif profile_selection.function_preset or profile_selection.functions:
-        resolved_scenario = _resolved_from_config(
+        resolved_scenario = resolved_scenario_from_config(
             profile_selection,
             name=f"profile-{saved_profile or 'default'}",
-            scenario=effective_scenario,
+            base_scenario=effective_scenario,
             runtime=effective_runtime,
             namespace=effective_namespace,
             local_registry=effective_registry,
@@ -394,10 +346,10 @@ def _resolve_run_request(
         scenario_source = f"saved profile: {saved_profile}"
     else:
         default_selection = _default_selection_for(effective_scenario)
-        resolved_scenario = _resolved_from_config(
+        resolved_scenario = resolved_scenario_from_config(
             default_selection,
             name=f"{effective_scenario}-default",
-            scenario=effective_scenario,
+            base_scenario=effective_scenario,
             runtime=effective_runtime,
             namespace=effective_namespace,
             local_registry=effective_registry,
@@ -518,8 +470,8 @@ def e2e_all(
     dry_run: bool = typer.Option(False, "--dry-run"),
 ) -> None:
     def _action() -> None:
-        selected_names = _parse_csv(only)
-        skipped_names = _parse_csv(skip)
+        selected_names = parse_function_csv(only)
+        skipped_names = parse_function_csv(skip)
         candidate_names = selected_names or [scenario.name for scenario in list_scenarios()]
         active_names = [scenario_name for scenario_name in candidate_names if scenario_name not in skipped_names]
         needs_vm = any(resolve_scenario(scenario_name).requires_vm for scenario_name in active_names)
@@ -539,8 +491,8 @@ def e2e_all(
 
         runner = _runner()
         plans = runner.plan_all(
-            only=_parse_csv(only),
-            skip=_parse_csv(skip),
+            only=selected_names,
+            skip=skipped_names,
             runtime=runtime,
             vm_request=vm_request,
             cleanup_vm=cleanup_vm,
@@ -557,8 +509,8 @@ def e2e_all(
         flow = resolve_flow_definition(
             "e2e.all",
             runner=runner,
-            only=_parse_csv(only),
-            skip=_parse_csv(skip),
+            only=selected_names,
+            skip=skipped_names,
             runtime=runtime,
             vm_request=vm_request,
             cleanup_vm=cleanup_vm,

--- a/tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py
+++ b/tools/controlplane/src/controlplane_tool/cli/loadtest_commands.py
@@ -20,8 +20,9 @@ from controlplane_tool.core.models import (
     ScenarioSelectionConfig,
     TestsConfig,
 )
-from controlplane_tool.workspace.paths import default_tool_paths, resolve_workspace_path
+from controlplane_tool.workspace.paths import default_tool_paths
 from controlplane_tool.workspace.profiles import load_profile as load_saved_profile, profile_path
+from controlplane_tool.scenario.selection_resolution import configured_scenario_path
 from controlplane_tool.scenario.scenario_loader import load_scenario_file, resolve_scenario_spec
 from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
 
@@ -84,21 +85,18 @@ def _default_profile_for_scenario(name: str, scenario: ResolvedScenario) -> Prof
     )
 
 
-def _configured_scenario_path(path: str | None) -> Path | None:
-    if not path:
-        return None
-    return resolve_workspace_path(Path(path))
-
-
 def _resolve_scenario(profile: Profile, scenario_file: Path | None) -> ResolvedScenario:
     if scenario_file is not None:
-        return load_scenario_file(resolve_workspace_path(scenario_file))
+        resolved_scenario_file = configured_scenario_path(scenario_file)
+        if resolved_scenario_file is None:
+            raise FileNotFoundError(str(scenario_file))
+        return load_scenario_file(resolved_scenario_file)
 
-    configured_loadtest_scenario = _configured_scenario_path(profile.loadtest.scenario_file)
+    configured_loadtest_scenario = configured_scenario_path(profile.loadtest.scenario_file)
     if configured_loadtest_scenario is not None:
         return load_scenario_file(configured_loadtest_scenario)
 
-    configured_profile_scenario = _configured_scenario_path(profile.scenario.scenario_file)
+    configured_profile_scenario = configured_scenario_path(profile.scenario.scenario_file)
     if configured_profile_scenario is not None:
         return load_scenario_file(configured_profile_scenario)
 
@@ -133,7 +131,10 @@ def build_loadtest_request(
         scenario = _resolve_scenario(active_profile, scenario_file)
         active_profile = active_profile.model_copy(update={"name": saved_profile}, deep=True)
     elif scenario_file is not None:
-        scenario = load_scenario_file(resolve_workspace_path(scenario_file))
+        resolved_scenario_file = configured_scenario_path(scenario_file)
+        if resolved_scenario_file is None:
+            raise FileNotFoundError(str(scenario_file))
+        scenario = load_scenario_file(resolved_scenario_file)
         active_profile = _default_profile_for_scenario(run_name or scenario.name, scenario)
     else:
         active_profile = _default_profile_for_scenario(
@@ -218,7 +219,7 @@ def _build_request_or_exit(
         )
     except FileNotFoundError as exc:
         resolved_path = (
-            resolve_workspace_path(scenario_file)
+            configured_scenario_path(scenario_file)
             if scenario_file is not None
             else (
                 Path(exc.filename).resolve()

--- a/tools/controlplane/src/controlplane_tool/cli/test_commands.py
+++ b/tools/controlplane/src/controlplane_tool/cli/test_commands.py
@@ -12,14 +12,17 @@ from controlplane_tool.cli_validation.cli_test_catalog import (
 from controlplane_tool.cli_validation.cli_test_models import CliTestRequest
 from controlplane_tool.cli_validation.cli_test_runner import CliTestPlan, CliTestRunner
 from controlplane_tool.core.models import ScenarioSelectionConfig
-from controlplane_tool.workspace.paths import default_tool_paths, resolve_workspace_path
+from controlplane_tool.workspace.paths import default_tool_paths
 from controlplane_tool.workspace.profiles import load_profile, profile_path
-from controlplane_tool.scenario.scenario_loader import (
-    load_scenario_file,
-    overlay_scenario_selection,
-    resolve_scenario_spec,
+from controlplane_tool.scenario.scenario_loader import load_scenario_file
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    explicit_selection_requested,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
 )
-from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
+from controlplane_tool.scenario.scenario_models import ResolvedScenario
 from controlplane_tool.infra.vm.vm_models import VmRequest
 
 CLI_TEST_CONTEXT_SETTINGS = {
@@ -35,18 +38,6 @@ cli_test_app = typer.Typer(
 
 def _runner() -> CliTestRunner:
     return CliTestRunner(default_tool_paths().workspace_root)
-
-
-def _parse_csv(value: str | None) -> list[str]:
-    if not value:
-        return []
-    return [item.strip() for item in value.split(",") if item.strip()]
-
-
-def _configured_scenario_path(path: str | None) -> Path | None:
-    if not path:
-        return None
-    return resolve_workspace_path(Path(path))
 
 
 def _build_vm_request(
@@ -69,45 +60,6 @@ def _build_vm_request(
         cpus=cpus,
         memory=memory,
         disk=disk,
-    )
-
-
-def _resolved_from_config(
-    config: ScenarioSelectionConfig,
-    *,
-    name: str,
-    default_base_scenario: str,
-    runtime: str,
-    namespace: str | None,
-    local_registry: str,
-) -> ResolvedScenario:
-    return resolve_scenario_spec(
-        ScenarioSpec(
-            name=name,
-            base_scenario=config.base_scenario or default_base_scenario,
-            runtime=runtime,
-            function_preset=config.function_preset,
-            functions=list(config.functions),
-            namespace=namespace if namespace is not None else config.namespace,
-            local_registry=local_registry or config.local_registry,
-        )
-    )
-
-
-def _reload_with_overrides(
-    scenario: ResolvedScenario,
-    *,
-    runtime: str,
-    namespace: str | None,
-    local_registry: str,
-) -> ResolvedScenario:
-    return overlay_scenario_selection(
-        scenario,
-        function_preset=scenario.function_preset,
-        functions=[] if scenario.function_preset else list(scenario.function_keys),
-        runtime=runtime,
-        namespace=namespace,
-        local_registry=local_registry,
     )
 
 
@@ -146,15 +98,6 @@ def _handle_validation(action) -> None:
         raise typer.Exit(code=2)
 
 
-def _has_explicit_selection(
-    *,
-    function_preset: str | None,
-    explicit_functions: list[str],
-    scenario_file: Path | None,
-) -> bool:
-    return bool(function_preset or explicit_functions or scenario_file is not None)
-
-
 def _load_profile_or_raise(name: str | None):
     if name is None:
         return None
@@ -166,7 +109,9 @@ def _load_profile_or_raise(name: str | None):
 def _load_scenario_or_raise(path: Path | None) -> ResolvedScenario | None:
     if path is None:
         return None
-    resolved_path = resolve_workspace_path(path)
+    resolved_path = configured_scenario_path(path)
+    if resolved_path is None:
+        return None
     if not resolved_path.exists():
         raise FileNotFoundError(f"Scenario file not found: {resolved_path}")
     return load_scenario_file(resolved_path)
@@ -192,7 +137,7 @@ def _resolve_run_request(
     scenario_file: Path | None,
     saved_profile: str | None,
 ) -> CliTestRequest:
-    explicit_functions = _parse_csv(functions_csv)
+    explicit_functions = parse_function_csv(functions_csv)
     if function_preset and explicit_functions:
         raise ValueError("function selection must use only one of --function-preset or --functions")
 
@@ -209,10 +154,10 @@ def _resolve_run_request(
         )
 
     scenario_definition = resolve_cli_test_scenario(effective_scenario)
-    explicit_file_path = _configured_scenario_path(str(scenario_file)) if scenario_file is not None else None
-    has_explicit_selection = _has_explicit_selection(
+    explicit_file_path = configured_scenario_path(scenario_file) if scenario_file is not None else None
+    has_explicit_selection = explicit_selection_requested(
         function_preset=function_preset,
-        explicit_functions=explicit_functions,
+        functions=explicit_functions,
         scenario_file=explicit_file_path,
     )
 
@@ -220,7 +165,7 @@ def _resolve_run_request(
         raise ValueError(f"scenario '{effective_scenario}' does not accept function selection")
 
     profile_file_path = (
-        _configured_scenario_path(profile_selection.scenario_file)
+        configured_scenario_path(profile_selection.scenario_file)
         if scenario_definition.accepts_function_selection
         else None
     )
@@ -267,7 +212,7 @@ def _resolve_run_request(
 
         if function_preset or explicit_functions:
             if explicit_file_scenario is not None:
-                resolved_scenario = overlay_scenario_selection(
+                resolved_scenario = overlay_selected_scenario(
                     explicit_file_scenario,
                     function_preset=function_preset,
                     functions=explicit_functions,
@@ -277,7 +222,7 @@ def _resolve_run_request(
                 )
                 scenario_source = "scenario file + CLI override"
             elif profile_file_scenario is not None:
-                resolved_scenario = overlay_scenario_selection(
+                resolved_scenario = overlay_selected_scenario(
                     profile_file_scenario,
                     function_preset=function_preset,
                     functions=explicit_functions,
@@ -288,7 +233,7 @@ def _resolve_run_request(
                 scenario_source = f"saved profile: {saved_profile} + CLI override"
                 request_scenario_file = profile_file_path
             else:
-                resolved_scenario = _resolved_from_config(
+                resolved_scenario = resolved_scenario_from_config(
                     ScenarioSelectionConfig(
                         base_scenario=profile_selection.base_scenario or default_base_scenario,
                         function_preset=function_preset,
@@ -297,14 +242,14 @@ def _resolve_run_request(
                         local_registry=effective_registry,
                     ),
                     name=f"{effective_scenario}-cli-test",
-                    default_base_scenario=default_base_scenario,
+                    base_scenario=profile_selection.base_scenario or default_base_scenario,
                     runtime=effective_runtime,
                     namespace=effective_namespace,
                     local_registry=effective_registry,
                 )
                 scenario_source = "explicit CLI override"
         elif explicit_file_scenario is not None:
-            resolved_scenario = _reload_with_overrides(
+            resolved_scenario = overlay_selected_scenario(
                 explicit_file_scenario,
                 runtime=effective_runtime,
                 namespace=effective_namespace,
@@ -312,7 +257,7 @@ def _resolve_run_request(
             )
             scenario_source = f"scenario file: {explicit_file_scenario.source_path}"
         elif profile_file_scenario is not None:
-            resolved_scenario = _reload_with_overrides(
+            resolved_scenario = overlay_selected_scenario(
                 profile_file_scenario,
                 runtime=effective_runtime,
                 namespace=effective_namespace,
@@ -321,10 +266,10 @@ def _resolve_run_request(
             scenario_source = f"saved profile: {saved_profile}"
             request_scenario_file = profile_file_path
         elif profile_selection.function_preset or profile_selection.functions:
-            resolved_scenario = _resolved_from_config(
+            resolved_scenario = resolved_scenario_from_config(
                 profile_selection,
                 name=f"profile-{saved_profile or 'default'}",
-                default_base_scenario=default_base_scenario,
+                base_scenario=profile_selection.base_scenario or default_base_scenario,
                 runtime=effective_runtime,
                 namespace=effective_namespace,
                 local_registry=effective_registry,

--- a/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.core.models import ScenarioSelectionConfig
+from controlplane_tool.scenario.scenario_loader import (
+    overlay_scenario_selection,
+    resolve_scenario_spec,
+)
+from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
+from controlplane_tool.workspace.paths import resolve_workspace_path
+
+
+def parse_function_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def configured_scenario_path(path: str | Path | None) -> Path | None:
+    if path is None:
+        return None
+    text = str(path).strip()
+    if not text:
+        return None
+    return resolve_workspace_path(Path(text))
+
+
+def explicit_selection_requested(
+    *,
+    function_preset: str | None,
+    functions: list[str],
+    scenario_file: Path | None,
+) -> bool:
+    return bool(function_preset or functions or scenario_file is not None)
+
+
+def resolved_scenario_from_config(
+    config: ScenarioSelectionConfig,
+    *,
+    name: str,
+    base_scenario: str,
+    runtime: str,
+    namespace: str | None,
+    local_registry: str,
+) -> ResolvedScenario:
+    return resolve_scenario_spec(
+        ScenarioSpec(
+            name=name,
+            base_scenario=config.base_scenario or base_scenario,
+            runtime=runtime,
+            function_preset=config.function_preset,
+            functions=list(config.functions),
+            namespace=namespace if namespace is not None else config.namespace,
+            local_registry=local_registry or config.local_registry,
+        )
+    )
+
+
+def overlay_selected_scenario(
+    scenario: ResolvedScenario,
+    *,
+    base_scenario: str | None = None,
+    runtime: str,
+    namespace: str | None,
+    local_registry: str,
+) -> ResolvedScenario:
+    source = (
+        scenario.model_copy(update={"base_scenario": base_scenario})
+        if base_scenario is not None
+        else scenario
+    )
+    return overlay_scenario_selection(
+        source,
+        function_preset=scenario.function_preset,
+        functions=[] if scenario.function_preset else list(scenario.function_keys),
+        runtime=runtime,
+        namespace=namespace,
+        local_registry=local_registry,
+    )

--- a/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
@@ -47,7 +47,7 @@ def resolved_scenario_from_config(
     return resolve_scenario_spec(
         ScenarioSpec(
             name=name,
-            base_scenario=config.base_scenario or base_scenario,
+            base_scenario=base_scenario,
             runtime=runtime,
             function_preset=config.function_preset,
             functions=list(config.functions),

--- a/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final, cast
 
 from controlplane_tool.core.models import ScenarioSelectionConfig
 from controlplane_tool.scenario.scenario_loader import (
@@ -9,6 +10,8 @@ from controlplane_tool.scenario.scenario_loader import (
 )
 from controlplane_tool.scenario.scenario_models import ResolvedScenario, ScenarioSpec
 from controlplane_tool.workspace.paths import resolve_workspace_path
+
+_FUNCTION_SELECTION_UNSET: Final = object()
 
 
 def parse_function_csv(value: str | None) -> list[str]:
@@ -61,7 +64,7 @@ def overlay_selected_scenario(
     scenario: ResolvedScenario,
     *,
     base_scenario: str | None = None,
-    function_preset: str | None = None,
+    function_preset: str | None | object = _FUNCTION_SELECTION_UNSET,
     functions: list[str] | None = None,
     runtime: str,
     namespace: str | None,
@@ -74,9 +77,13 @@ def overlay_selected_scenario(
     )
     selected_preset = scenario.function_preset
     selected_functions = [] if scenario.function_preset else list(scenario.function_keys)
-    if functions is not None:
-        selected_preset = function_preset
-        selected_functions = functions
+    if function_preset is not _FUNCTION_SELECTION_UNSET or functions is not None:
+        selected_preset = (
+            cast(str | None, function_preset)
+            if function_preset is not _FUNCTION_SELECTION_UNSET
+            else None
+        )
+        selected_functions = functions if functions is not None else []
     return overlay_scenario_selection(
         source,
         function_preset=selected_preset,

--- a/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/selection_resolution.py
@@ -61,6 +61,8 @@ def overlay_selected_scenario(
     scenario: ResolvedScenario,
     *,
     base_scenario: str | None = None,
+    function_preset: str | None = None,
+    functions: list[str] | None = None,
     runtime: str,
     namespace: str | None,
     local_registry: str,
@@ -70,10 +72,15 @@ def overlay_selected_scenario(
         if base_scenario is not None
         else scenario
     )
+    selected_preset = scenario.function_preset
+    selected_functions = [] if scenario.function_preset else list(scenario.function_keys)
+    if functions is not None:
+        selected_preset = function_preset
+        selected_functions = functions
     return overlay_scenario_selection(
         source,
-        function_preset=scenario.function_preset,
-        functions=[] if scenario.function_preset else list(scenario.function_keys),
+        function_preset=selected_preset,
+        functions=selected_functions,
         runtime=runtime,
         namespace=namespace,
         local_registry=local_registry,

--- a/tools/controlplane/tests/test_architecture_docs.py
+++ b/tools/controlplane/tests/test_architecture_docs.py
@@ -15,3 +15,13 @@ def test_tool_readme_documents_package_architecture_checks() -> None:
     assert "uv run controlplane-package-report" in readme
     assert "uv run pydeps controlplane_tool" in readme
     assert "GitNexus" in readme
+
+
+def test_tool_readme_documents_shared_selection_resolution_boundary() -> None:
+    readme = resolve_workspace_path(Path("tools/controlplane/README.md")).read_text(
+        encoding="utf-8"
+    )
+
+    assert "controlplane_tool.scenario.selection_resolution" in readme
+    assert "ScenarioSelectionConfig" in readme
+    assert "controlplane_tool.scenario.scenario_loader" in readme

--- a/tools/controlplane/tests/test_cli_test_commands.py
+++ b/tools/controlplane/tests/test_cli_test_commands.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from controlplane_tool.app.main import app
@@ -94,6 +96,77 @@ def test_cli_test_run_deploy_host_dry_run_accepts_demo_java_preset() -> None:
 
     assert result.exit_code == 0
     assert "Resolved Functions: word-stats-java, json-transform-java" in result.stdout
+
+
+def test_cli_test_request_applies_cli_override_to_saved_profile_scenario_file(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import controlplane_tool.cli.test_commands as test_commands
+    from controlplane_tool.cli.test_commands import _resolve_run_request
+    from controlplane_tool.core.models import (
+        CliTestConfig,
+        ControlPlaneConfig,
+        Profile,
+        ScenarioSelectionConfig,
+    )
+
+    scenario_file = tmp_path / "scenario.toml"
+    scenario_file.write_text(
+        """
+name = "custom"
+base_scenario = "cli-stack"
+runtime = "java"
+function_preset = "demo-java"
+namespace = "from-file"
+local_registry = "registry:5000"
+""",
+        encoding="utf-8",
+    )
+    profile_file = tmp_path / "profile.toml"
+    profile_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(test_commands, "profile_path", lambda name: profile_file)
+    monkeypatch.setattr(
+        test_commands,
+        "load_profile",
+        lambda name: Profile(
+            name=name,
+            control_plane=ControlPlaneConfig(implementation="java", build_mode="jvm"),
+            scenario=ScenarioSelectionConfig(scenario_file=str(scenario_file)),
+            cli_test=CliTestConfig(default_scenario="cli-stack"),
+        ),
+    )
+
+    request = _resolve_run_request(
+        scenario=None,
+        runtime="rust",
+        lifecycle="external",
+        name=None,
+        host="127.0.0.1",
+        user="ubuntu",
+        home=None,
+        cpus=2,
+        memory="2G",
+        disk="10G",
+        keep_vm=True,
+        namespace="override",
+        local_registry="localhost:5001",
+        function_preset="demo-javascript",
+        functions_csv=None,
+        scenario_file=None,
+        saved_profile="saved",
+    )
+
+    assert request.resolved_scenario is not None
+    assert request.resolved_scenario.runtime == "rust"
+    assert request.resolved_scenario.namespace == "override"
+    assert request.resolved_scenario.local_registry == "localhost:5001"
+    assert request.resolved_scenario.function_preset == "demo-javascript"
+    assert request.resolved_scenario.function_keys == [
+        "word-stats-javascript",
+        "json-transform-javascript",
+    ]
 
 
 def test_cli_test_run_missing_saved_profile_exits_cleanly() -> None:

--- a/tools/controlplane/tests/test_e2e_commands.py
+++ b/tools/controlplane/tests/test_e2e_commands.py
@@ -229,6 +229,67 @@ def test_e2e_explicit_functions_override_saved_profile_defaults(monkeypatch) -> 
     assert "json-transform-java" not in result.stdout
 
 
+def test_e2e_request_applies_cli_override_to_saved_profile_scenario_file(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import controlplane_tool.cli.e2e_commands as e2e_commands
+    from controlplane_tool.core.models import (
+        ControlPlaneConfig,
+        Profile,
+        ScenarioSelectionConfig,
+    )
+
+    scenario_file = tmp_path / "scenario.toml"
+    scenario_file.write_text(
+        """
+name = "custom"
+base_scenario = "k3s-junit-curl"
+runtime = "java"
+function_preset = "demo-java"
+namespace = "from-file"
+local_registry = "registry:5000"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        e2e_commands,
+        "load_profile",
+        lambda name: Profile(
+            name=name,
+            control_plane=ControlPlaneConfig(implementation="java", build_mode="jvm"),
+            scenario=ScenarioSelectionConfig(scenario_file=str(scenario_file)),
+        ),
+    )
+
+    request = _resolve_run_request(
+        scenario=None,
+        runtime="rust",
+        lifecycle="external",
+        name=None,
+        host="127.0.0.1",
+        user="ubuntu",
+        home=None,
+        cpus=2,
+        memory="2G",
+        disk="10G",
+        cleanup_vm=True,
+        namespace="override",
+        local_registry="localhost:5001",
+        function_preset="demo-java",
+        functions_csv=None,
+        scenario_file=None,
+        saved_profile="saved",
+    )
+
+    assert request.resolved_scenario is not None
+    assert request.resolved_scenario.runtime == "rust"
+    assert request.resolved_scenario.namespace == "override"
+    assert request.resolved_scenario.local_registry == "localhost:5001"
+    assert request.resolved_scenario.function_preset == "demo-java"
+
+
 def test_e2e_run_executes_prefect_flow(monkeypatch) -> None:
     runner = CliRunner()
     called: dict[str, str] = {}

--- a/tools/controlplane/tests/test_e2e_commands.py
+++ b/tools/controlplane/tests/test_e2e_commands.py
@@ -277,7 +277,7 @@ local_registry = "registry:5000"
         cleanup_vm=True,
         namespace="override",
         local_registry="localhost:5001",
-        function_preset="demo-java",
+        function_preset="demo-javascript",
         functions_csv=None,
         scenario_file=None,
         saved_profile="saved",
@@ -287,7 +287,11 @@ local_registry = "registry:5000"
     assert request.resolved_scenario.runtime == "rust"
     assert request.resolved_scenario.namespace == "override"
     assert request.resolved_scenario.local_registry == "localhost:5001"
-    assert request.resolved_scenario.function_preset == "demo-java"
+    assert request.resolved_scenario.function_preset == "demo-javascript"
+    assert request.resolved_scenario.function_keys == [
+        "word-stats-javascript",
+        "json-transform-javascript",
+    ]
 
 
 def test_e2e_run_executes_prefect_flow(monkeypatch) -> None:

--- a/tools/controlplane/tests/test_selection_resolution.py
+++ b/tools/controlplane/tests/test_selection_resolution.py
@@ -142,3 +142,30 @@ def test_overlay_selected_scenario_accepts_explicit_function_override() -> None:
 
     assert updated.function_preset is None
     assert updated.function_keys == ["word-stats-java"]
+
+
+def test_overlay_selected_scenario_accepts_explicit_preset_override() -> None:
+    original = resolve_scenario_spec(
+        ScenarioSpec(
+            name="manifest",
+            base_scenario="k3s-junit-curl",
+            runtime="java",
+            function_preset="demo-java",
+            namespace="original",
+            local_registry="registry:5000",
+        )
+    )
+
+    updated = overlay_selected_scenario(
+        original,
+        function_preset="demo-javascript",
+        runtime="java",
+        namespace="override",
+        local_registry="localhost:5001",
+    )
+
+    assert updated.function_preset == "demo-javascript"
+    assert updated.function_keys == [
+        "word-stats-javascript",
+        "json-transform-javascript",
+    ]

--- a/tools/controlplane/tests/test_selection_resolution.py
+++ b/tools/controlplane/tests/test_selection_resolution.py
@@ -116,3 +116,29 @@ def test_overlay_selected_scenario_preserves_manifest_functions_with_overrides()
     assert updated.namespace == "override"
     assert updated.local_registry == "localhost:5001"
     assert updated.function_keys == ["word-stats-java"]
+
+
+def test_overlay_selected_scenario_accepts_explicit_function_override() -> None:
+    original = resolve_scenario_spec(
+        ScenarioSpec(
+            name="manifest",
+            base_scenario="k3s-junit-curl",
+            runtime="java",
+            function_preset="demo-java",
+            namespace="original",
+            local_registry="registry:5000",
+        )
+    )
+
+    updated = overlay_selected_scenario(
+        original,
+        base_scenario="k3s-junit-curl",
+        function_preset=None,
+        functions=["word-stats-java"],
+        runtime="java",
+        namespace="override",
+        local_registry="localhost:5001",
+    )
+
+    assert updated.function_preset is None
+    assert updated.function_keys == ["word-stats-java"]

--- a/tools/controlplane/tests/test_selection_resolution.py
+++ b/tools/controlplane/tests/test_selection_resolution.py
@@ -75,6 +75,22 @@ def test_resolved_scenario_from_config_uses_default_base_scenario() -> None:
     assert scenario.function_preset == "demo-java"
 
 
+def test_resolved_scenario_from_config_prefers_argument_base_scenario() -> None:
+    scenario = resolved_scenario_from_config(
+        ScenarioSelectionConfig(
+            base_scenario="cli-stack",
+            function_preset="demo-java",
+        ),
+        name="cli-test-selection",
+        base_scenario="k3s-junit-curl",
+        runtime="java",
+        namespace="demo",
+        local_registry="localhost:5000",
+    )
+
+    assert scenario.base_scenario == "k3s-junit-curl"
+
+
 def test_overlay_selected_scenario_preserves_manifest_functions_with_overrides() -> None:
     original = resolve_scenario_spec(
         ScenarioSpec(

--- a/tools/controlplane/tests/test_selection_resolution.py
+++ b/tools/controlplane/tests/test_selection_resolution.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from controlplane_tool.core.models import ScenarioSelectionConfig
+from controlplane_tool.scenario.scenario_loader import resolve_scenario_spec
+from controlplane_tool.scenario.scenario_models import ScenarioSpec
+from controlplane_tool.scenario.selection_resolution import (
+    configured_scenario_path,
+    explicit_selection_requested,
+    overlay_selected_scenario,
+    parse_function_csv,
+    resolved_scenario_from_config,
+)
+
+
+def test_parse_function_csv_trims_empty_items() -> None:
+    assert parse_function_csv(" word-stats-java, ,json-transform-java ") == [
+        "word-stats-java",
+        "json-transform-java",
+    ]
+
+
+def test_configured_scenario_path_resolves_workspace_relative_path() -> None:
+    result = configured_scenario_path("tools/controlplane/scenarios/k8s-demo-java.toml")
+
+    assert result is not None
+    assert result.is_absolute()
+    assert result.name == "k8s-demo-java.toml"
+
+
+def test_configured_scenario_path_keeps_none_empty() -> None:
+    assert configured_scenario_path(None) is None
+    assert configured_scenario_path("") is None
+
+
+def test_explicit_selection_requested_detects_preset_functions_or_file() -> None:
+    assert explicit_selection_requested(
+        function_preset="demo-java",
+        functions=[],
+        scenario_file=None,
+    )
+    assert explicit_selection_requested(
+        function_preset=None,
+        functions=["word-stats-java"],
+        scenario_file=None,
+    )
+    assert explicit_selection_requested(
+        function_preset=None,
+        functions=[],
+        scenario_file=Path("scenario.toml"),
+    )
+    assert not explicit_selection_requested(
+        function_preset=None,
+        functions=[],
+        scenario_file=None,
+    )
+
+
+def test_resolved_scenario_from_config_uses_default_base_scenario() -> None:
+    scenario = resolved_scenario_from_config(
+        ScenarioSelectionConfig(function_preset="demo-java"),
+        name="cli-test-selection",
+        base_scenario="k3s-junit-curl",
+        runtime="java",
+        namespace="demo",
+        local_registry="localhost:5000",
+    )
+
+    assert scenario.name == "cli-test-selection"
+    assert scenario.base_scenario == "k3s-junit-curl"
+    assert scenario.runtime == "java"
+    assert scenario.namespace == "demo"
+    assert scenario.local_registry == "localhost:5000"
+    assert scenario.function_preset == "demo-java"
+
+
+def test_overlay_selected_scenario_preserves_manifest_functions_with_overrides() -> None:
+    original = resolve_scenario_spec(
+        ScenarioSpec(
+            name="manifest",
+            base_scenario="k3s-junit-curl",
+            runtime="java",
+            functions=["word-stats-java"],
+            namespace="original",
+            local_registry="registry:5000",
+        )
+    )
+
+    updated = overlay_selected_scenario(
+        original,
+        base_scenario="cli-stack",
+        runtime="rust",
+        namespace="override",
+        local_registry="localhost:5001",
+    )
+
+    assert updated.base_scenario == "cli-stack"
+    assert updated.runtime == "rust"
+    assert updated.namespace == "override"
+    assert updated.local_registry == "localhost:5001"
+    assert updated.function_keys == ["word-stats-java"]


### PR DESCRIPTION
## Summary
- Add shared scenario selection resolution helpers under controlplane_tool.scenario.
- Reuse the shared helpers from e2e, cli-test, and loadtest CLI surfaces.
- Document the shared selection boundary and add regression coverage for saved-profile scenario overrides.

## Test Plan
- uv run pytest tests/test_selection_resolution.py tests/test_e2e_commands.py tests/test_cli_test_commands.py tests/test_loadtest_commands.py tests/test_architecture_docs.py -q
- uv run lint-imports
- uv run controlplane-package-report