### PR TITLE
chore: delete bash compatibility-wrapper scripts; one launcher (sub-5/6-a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@
 - `./gradlew :control-plane:bootBuildImage` and `:function-runtime:bootBuildImage` — create buildpack images.
 - `python-runtime/build.sh` or `docker build -t nanofaas/python-runtime python-runtime/` — build Python runtime image.
 - `scripts/native-build.sh` — build GraalVM native binaries (uses SDKMAN).
-- `scripts/e2e.sh` and `scripts/e2e-buildpack.sh` — run local E2E suites.
-- `scripts/e2e-k3s-junit-curl.sh` — provision a Multipass VM with k3s, deploy via Helm, run curl checks, and then run `K8sE2eTest`.
+- `scripts/controlplane.sh e2e run docker` and `scripts/controlplane.sh e2e run buildpack` — run local E2E suites.
+- `scripts/controlplane.sh e2e run k3s-junit-curl` — provision a Multipass VM with k3s, deploy via Helm, run curl checks, and then run `K8sE2eTest`.
 
 ## Coding Style & Naming Conventions
 
@@ -32,7 +32,7 @@
 
 - JUnit 5 is the primary framework; tests are named `*Test.java`.
 - E2E tests use Testcontainers, RestAssured, and Fabric8; ensure Docker/compatible runtime is available.
-- K8s E2E (`K8sE2eTest`) runs via `scripts/e2e-k3s-junit-curl.sh` on a real k3s cluster in Multipass.
+- K8s E2E (`K8sE2eTest`) runs via `scripts/controlplane.sh e2e run k3s-junit-curl` on a real k3s cluster in Multipass.
 
 ## Project Constraints & Requirements (FaaS MVP)
 
@@ -52,7 +52,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **mcFaas** (15251 symbols, 41405 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **mcFaas** (15739 symbols, 42753 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -56,9 +56,9 @@ The system consists of four main modules:
 | **Build All** | `./gradlew build` |
 | **Run Tests** | `./gradlew test` |
 | **Run Specific Test** | `./gradlew :control-plane:test --tests com.nanofaas.controlplane.core.QueueManagerTest` |
-| **Local E2E** | `./scripts/e2e.sh` (Uses Testcontainers) |
-| **Buildpack E2E** | `./scripts/e2e-buildpack.sh` |
-| **K8s E2E** | `./scripts/e2e-k3s-junit-curl.sh` or `./gradlew k8sE2e` |
+| **Local E2E** | `./scripts/controlplane.sh e2e run docker` (Uses Testcontainers) |
+| **Buildpack E2E** | `./scripts/controlplane.sh e2e run buildpack` |
+| **K8s E2E** | `./scripts/controlplane.sh e2e run k3s-junit-curl` or `./gradlew k8sE2e` |
 
 ### Running Locally
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ tasks.register('k8sE2e') {
 tasks.register('k8sE2eVm', Exec) {
     group = 'verification'
     description = 'Run K8sE2eTest in an ephemeral Multipass VM with k3s.'
-    commandLine 'bash', 'scripts/e2e-k3s-junit-curl.sh'
+    commandLine 'bash', 'scripts/controlplane.sh', 'e2e', 'run', 'k3s-junit-curl'
 }
 
 tasks.register('verifyHelmVersionSync') {

--- a/control-plane/build.gradle
+++ b/control-plane/build.gradle
@@ -140,7 +140,7 @@ if (k8sDisk) {
 if (k8sRemoteDir) {
     k8sEnv.REMOTE_DIR = k8sRemoteDir.toString()
 }
-def k8sE2eCommand = ['bash', 'scripts/e2e-k3s-junit-curl.sh']
+def k8sE2eCommand = ['bash', 'scripts/controlplane.sh', 'e2e', 'run', 'k3s-junit-curl']
 if (!k8sCleanupVm) {
     k8sE2eCommand << '--no-cleanup-vm'
 }

--- a/docs/superpowers/plans/2026-05-31-sub5a-remove-compat-wrappers.md
+++ b/docs/superpowers/plans/2026-05-31-sub5a-remove-compat-wrappers.md
@@ -1,0 +1,191 @@
+# Sub-5/6-a — Remove bash compatibility-wrapper scripts (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the 9 bash compatibility-wrapper scripts and repoint every live consumer (a Gradle task, two experiment scripts, and the docs) to the single canonical launcher `scripts/controlplane.sh`.
+
+**Architecture:** Repoint-then-delete. First update the consumers (Gradle `commandLine`, two band-C experiment scripts, all live docs) so nothing breaks, then delete the wrappers, then grep-verify no live reference remains. No Python/tests change — verification is grep + `bash -n` + Gradle task resolution.
+
+**Tech Stack:** bash, Gradle, Markdown docs.
+
+**Baseline:** branch `refactor/wt-sub5a-remove-compat-wrappers` (already created). Spec: `docs/superpowers/specs/2026-05-31-remove-compat-wrapper-scripts-design.md`. The launchers `scripts/controlplane.sh` and `scripts/fn-init.sh` STAY. Band-B (`e2e-loadtest.sh`, `build-push-images.sh`, `native-build.sh`, `k6/run-all.sh`, `experiments/run.sh`) and band-C (the big experiment scripts) are NOT deleted here — keep all their references intact.
+
+**The 9 wrappers to delete and their `controlplane.sh` equivalents:**
+
+| Wrapper (delete) | Replacement |
+|---|---|
+| `scripts/e2e.sh` | `scripts/controlplane.sh e2e run docker` |
+| `scripts/e2e-all.sh` | `scripts/controlplane.sh e2e all` |
+| `scripts/e2e-k3s-junit-curl.sh` | `scripts/controlplane.sh e2e run k3s-junit-curl` |
+| `scripts/e2e-k3s-helm.sh` | `scripts/controlplane.sh e2e run helm-stack` |
+| `scripts/e2e-container-local.sh` | `scripts/controlplane.sh e2e run container-local` |
+| `scripts/e2e-buildpack.sh` | `scripts/controlplane.sh e2e run buildpack` |
+| `scripts/control-plane-build.sh` | `scripts/controlplane.sh` |
+| `scripts/control-plane-building.sh` | `scripts/controlplane.sh` |
+| `scripts/controlplane-tool.sh` | `scripts/controlplane.sh tui` |
+
+---
+
+### Task 1: Repoint the code/build consumers
+
+**Files:**
+- Modify: `build.gradle:70`
+- Modify: `experiments/e2e-memory-ab.sh:205`
+- Modify: `experiments/e2e-runtime-ab.sh:128`
+
+- [ ] **Step 1: Repoint the Gradle `k8sE2eVm` task**
+
+In `build.gradle`, the task `k8sE2eVm` (registered at line 68) has at line 70:
+```gradle
+    commandLine 'bash', 'scripts/e2e-k3s-junit-curl.sh'
+```
+Change it to:
+```gradle
+    commandLine 'bash', 'scripts/controlplane.sh', 'e2e', 'run', 'k3s-junit-curl'
+```
+
+- [ ] **Step 2: Repoint the two band-C experiment scripts**
+
+In `experiments/e2e-memory-ab.sh`, line 205 is:
+```bash
+        bash "${PROJECT_ROOT}/scripts/e2e-k3s-helm.sh"
+```
+Change it to:
+```bash
+        bash "${PROJECT_ROOT}/scripts/controlplane.sh" e2e run helm-stack
+```
+
+In `experiments/e2e-runtime-ab.sh`, line 128 is identical:
+```bash
+        bash "${PROJECT_ROOT}/scripts/e2e-k3s-helm.sh"
+```
+Change it to:
+```bash
+        bash "${PROJECT_ROOT}/scripts/controlplane.sh" e2e run helm-stack
+```
+
+- [ ] **Step 3: Verify the edited scripts are syntactically valid**
+
+Run: `bash -n experiments/e2e-memory-ab.sh && bash -n experiments/e2e-runtime-ab.sh && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Verify the Gradle task still resolves with the new commandLine**
+
+Run: `./gradlew help --task k8sE2eVm 2>&1 | tail -20`
+Expected: prints the task help (`Detailed task information for k8sE2eVm`) with no configuration error. (Do NOT actually run the E2E task — it needs a VM.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build.gradle experiments/e2e-memory-ab.sh experiments/e2e-runtime-ab.sh
+git commit -m "build: point k8sE2eVm + AB experiments at scripts/controlplane.sh"
+```
+
+---
+
+### Task 2: Update the live docs
+
+**Files:**
+- Modify: `GEMINI.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/testing.md`
+- Modify: `tooling/controlplane_tui/README.md`
+
+- [ ] **Step 1: Substitute every deleted-wrapper path in the live docs**
+
+Run this from the repo root. It rewrites each wrapper path to its `controlplane.sh` equivalent across the four live doc files. The dots are escaped so `scripts/e2e.sh` does not match `scripts/e2e-loadtest.sh` (band B, kept) and `control-plane-build.sh` does not match `control-plane-building.sh`:
+
+```bash
+for f in GEMINI.md AGENTS.md docs/testing.md tooling/controlplane_tui/README.md; do
+  perl -i -pe '
+    s{scripts/e2e-k3s-junit-curl\.sh}{scripts/controlplane.sh e2e run k3s-junit-curl}g;
+    s{scripts/e2e-k3s-helm\.sh}{scripts/controlplane.sh e2e run helm-stack}g;
+    s{scripts/e2e-container-local\.sh}{scripts/controlplane.sh e2e run container-local}g;
+    s{scripts/e2e-buildpack\.sh}{scripts/controlplane.sh e2e run buildpack}g;
+    s{scripts/e2e-all\.sh}{scripts/controlplane.sh e2e all}g;
+    s{scripts/e2e\.sh}{scripts/controlplane.sh e2e run docker}g;
+    s{scripts/control-plane-building\.sh}{scripts/controlplane.sh}g;
+    s{scripts/control-plane-build\.sh}{scripts/controlplane.sh}g;
+    s{scripts/controlplane-tool\.sh}{scripts/controlplane.sh tui}g;
+  ' "$f"
+done
+```
+
+- [ ] **Step 2: Remove the now self-referential "wrapper over" line in `docs/testing.md`**
+
+After Step 1, `docs/testing.md` contains a line that reads (the `e2e-k3s-helm.sh` was rewritten):
+```
+`scripts/controlplane.sh e2e run helm-stack` is a wrapper over `scripts/controlplane.sh e2e run helm-stack`.
+```
+Delete that entire line (it described the now-deleted wrapper). Leave the adjacent line about `scripts/e2e-loadtest.sh` (band B — kept) untouched.
+
+Run to confirm the self-referential line is gone:
+`grep -n "is a wrapper over .scripts/controlplane.sh e2e run helm-stack" docs/testing.md`
+Expected: EMPTY.
+
+- [ ] **Step 3: Verify no deleted-wrapper reference remains in the live docs**
+
+Run:
+```bash
+grep -rn "scripts/e2e\.sh\|scripts/e2e-all\.sh\|scripts/e2e-k3s-junit-curl\.sh\|scripts/e2e-k3s-helm\.sh\|scripts/e2e-container-local\.sh\|scripts/e2e-buildpack\.sh\|scripts/control-plane-build\.sh\|scripts/control-plane-building\.sh\|scripts/controlplane-tool\.sh" \
+  GEMINI.md AGENTS.md docs/testing.md tooling/controlplane_tui/README.md CLAUDE.md README.md
+```
+Expected: EMPTY. (`e2e-loadtest.sh` references must still be present — they are band B; confirm with `grep -c "e2e-loadtest.sh" docs/testing.md` returns a non-zero count.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add GEMINI.md AGENTS.md docs/testing.md tooling/controlplane_tui/README.md
+git commit -m "docs: reference scripts/controlplane.sh instead of compat wrappers"
+```
+
+---
+
+### Task 3: Delete the wrapper scripts and final verification
+
+**Files:**
+- Delete: `scripts/e2e.sh`, `scripts/e2e-all.sh`, `scripts/e2e-k3s-junit-curl.sh`, `scripts/e2e-k3s-helm.sh`, `scripts/e2e-container-local.sh`, `scripts/e2e-buildpack.sh`, `scripts/control-plane-build.sh`, `scripts/control-plane-building.sh`, `scripts/controlplane-tool.sh`
+
+- [ ] **Step 1: Delete the 9 wrappers**
+
+```bash
+rm scripts/e2e.sh scripts/e2e-all.sh scripts/e2e-k3s-junit-curl.sh \
+   scripts/e2e-k3s-helm.sh scripts/e2e-container-local.sh scripts/e2e-buildpack.sh \
+   scripts/control-plane-build.sh scripts/control-plane-building.sh \
+   scripts/controlplane-tool.sh
+```
+
+- [ ] **Step 2: Confirm the launchers survive**
+
+Run: `ls scripts/controlplane.sh scripts/fn-init.sh`
+Expected: both listed (no error).
+
+- [ ] **Step 3: Final grep — no live reference to any deleted wrapper anywhere**
+
+Run (excludes the frozen experiment snapshots, node_modules, .git):
+```bash
+grep -rn "e2e\.sh\|e2e-all\.sh\|e2e-k3s-junit-curl\.sh\|e2e-k3s-helm\.sh\|e2e-container-local\.sh\|e2e-buildpack\.sh\|control-plane-build\.sh\|control-plane-building\.sh\|controlplane-tool\.sh" . \
+  --include="*.md" --include="*.sh" --include="*.gradle" --include="*.yml" --include="*.yaml" \
+| grep -v "experiments/control-plane-staging/versions/" | grep -v "node_modules\|\.git/"
+```
+Expected: EMPTY. (If a frozen snapshot under `experiments/control-plane-staging/versions/` still mentions a wrapper, that is fine and intentionally untouched — the filter above excludes it.)
+
+- [ ] **Step 4: Sanity-check the launcher still works**
+
+Run: `bash scripts/controlplane.sh --help 2>&1 | head -5`
+Expected: the controlplane-tool help output (no "No such file" / launcher error).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A scripts/
+git commit -m "chore: delete bash compatibility-wrapper scripts (use scripts/controlplane.sh)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** delete-9-wrappers = Task 3; repoint build.gradle = Task 1 Step 1; repoint band-C experiment scripts = Task 1 Step 2; update docs (GEMINI/AGENTS/testing.md/TUI README) = Task 2; the "wrapper over" prose line = Task 2 Step 2; keep launchers + band-B `e2e-loadtest.sh` = explicit in Task 2 Step 3 / Task 3 Step 2; don't touch frozen snapshots = Task 3 Step 3 filter; verification (grep + `bash -n` + gradle resolve + launcher --help) = Task 1 Step 3-4, Task 2 Step 3, Task 3 Step 3-4. ✓ No gaps.
+- **Placeholder scan:** none — exact old/new strings, exact rm/grep/perl commands, exact expected outputs.
+- **Consistency:** the same 9 wrapper→replacement mappings are used identically in the delete list, the doc substitution (Task 2 Step 1), and the verification greps. `e2e-loadtest.sh` is consistently preserved (band B). ✓

--- a/docs/superpowers/specs/2026-05-31-remove-compat-wrapper-scripts-design.md
+++ b/docs/superpowers/specs/2026-05-31-remove-compat-wrapper-scripts-design.md
@@ -1,0 +1,94 @@
+# Sub-5/6-a — Remove bash compatibility-wrapper scripts (Design)
+
+**Status:** approved (design), pending implementation plan
+**Date:** 2026-05-31
+**Roadmap:** first slice of the bash-elimination effort (sub-projects 5/6 of the
+workflow_tasks component-library roadmap). "One way to do things" — collapse the
+duplicate alias scripts onto the single canonical launcher `scripts/controlplane.sh`.
+
+## Context / landscape
+
+The repo has 39 `.sh` files. Most are **out of scope** for bash elimination:
+- `watchdog/*` — a separate component's own build/test scripts.
+- `examples/bash/*` — example FaaS handlers (product, not tooling).
+- `python-runtime/build.sh` — deprecated runtime's build.
+
+The in-scope workflow scripts split into three bands:
+- **A — compatibility wrappers** (this sub-project): ~9 five-line scripts that
+  only `exec scripts/controlplane.sh <subcommand> "$@"`.
+- **B — scripts with real logic** (later): `build-push-images.sh`,
+  `native-build.sh`, `e2e-loadtest.sh`, `experiments/k6/run-all.sh`,
+  `experiments/run.sh`.
+- **C — large experiment scripts** (final phase): `e2e-runtime-ab.sh`,
+  `e2e-memory-ab.sh`, `e2e-cold-start-metrics.sh`, `e2e-memory-ab-batch.sh`,
+  `e2e-runtime-config.sh`.
+
+`scripts/controlplane.sh` (`uv run --project tools/controlplane controlplane-tool "$@"`)
+and `scripts/fn-init.sh` are the legitimate launchers — **they stay**. CI
+(`.github/workflows/gitops.yml`) already invokes `controlplane.sh`, not the wrappers.
+
+## Goal
+
+Delete the 9 compatibility-wrapper scripts and repoint every consumer to
+`scripts/controlplane.sh <subcommand>`, so there is exactly one way to invoke each
+workflow.
+
+## Scripts to delete (all pure `exec controlplane.sh ...` aliases)
+
+| Wrapper | Equivalent |
+|---|---|
+| `scripts/e2e.sh` | `controlplane.sh e2e run docker` |
+| `scripts/e2e-all.sh` | `controlplane.sh e2e all` |
+| `scripts/e2e-k3s-junit-curl.sh` | `controlplane.sh e2e run k3s-junit-curl` |
+| `scripts/e2e-k3s-helm.sh` | `controlplane.sh e2e run helm-stack` |
+| `scripts/e2e-container-local.sh` | `controlplane.sh e2e run container-local` |
+| `scripts/e2e-buildpack.sh` | `controlplane.sh e2e run buildpack` |
+| `scripts/control-plane-build.sh` | `controlplane.sh "$@"` (passthrough) |
+| `scripts/control-plane-building.sh` | `controlplane.sh "$@"` (passthrough) |
+| `scripts/controlplane-tool.sh` | `controlplane.sh tui` |
+
+## Consumers to repoint first (then delete)
+
+1. **`build.gradle:70`** — the `k8sE2e` Gradle task runs
+   `commandLine 'bash', 'scripts/e2e-k3s-junit-curl.sh'`. Change to
+   `commandLine 'bash', 'scripts/controlplane.sh', 'e2e', 'run', 'k3s-junit-curl'`.
+   (`./gradlew k8sE2e` must keep working.)
+2. **Fascia-C experiment scripts** (stay until the final phase, only this line
+   changes): `experiments/e2e-memory-ab.sh:205` and `experiments/e2e-runtime-ab.sh:128`
+   call `bash "${PROJECT_ROOT}/scripts/e2e-k3s-helm.sh"` → change to
+   `bash "${PROJECT_ROOT}/scripts/controlplane.sh" e2e run helm-stack`.
+3. **Docs** — update every reference to a deleted wrapper to the
+   `scripts/controlplane.sh <subcommand>` form:
+   - `GEMINI.md` (lines ~59-61)
+   - `AGENTS.md` (lines ~22-23, 35)
+   - `docs/testing.md` (multiple: ~189, 245-321, 465-466)
+   - `tooling/controlplane_tui/README.md` (lines ~33-35: `controlplane-tool.sh` → `controlplane.sh tui`)
+   - `CLAUDE.md` — check/keep consistent (it already uses `controlplane.sh`).
+
+   Snapshot/archived docs under
+   `experiments/control-plane-staging/versions/.../snapshot/.../README.md` are
+   historical artifacts — **do not edit** (frozen snapshots).
+
+## Out of scope
+
+- Any script with real logic (band B) and the experiment scripts (band C).
+- `scripts/controlplane.sh`, `scripts/fn-init.sh` (the launchers — stay).
+- watchdog / examples / python-runtime scripts.
+- Editing frozen snapshot READMEs under `experiments/control-plane-staging/versions/`.
+
+## Testing / verification
+
+- `grep -rn` for each deleted wrapper basename across the repo (excluding
+  `experiments/control-plane-staging/versions/` snapshots, `node_modules`, `.git`)
+  → no live references remain.
+- `./gradlew k8sE2e --dry-run` (or at least `./gradlew help --task k8sE2e`) resolves;
+  the task's `commandLine` now points at `controlplane.sh`.
+- `bash -n` (syntax check) on the two edited experiment scripts.
+- `scripts/controlplane.sh --help` still works (sanity that the launcher is intact).
+
+## Success criteria
+
+- The 9 wrapper files are gone; `controlplane.sh` + `fn-init.sh` remain.
+- `build.gradle`, the two experiment scripts, and all live docs reference
+  `controlplane.sh`.
+- No live reference to any deleted wrapper basename remains.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -186,7 +186,7 @@ E2E_KUBECONFIG_SERVER=<optional-https-server-url>
 Examples:
 
 ```bash
-E2E_VM_LIFECYCLE=external E2E_VM_HOST=192.168.64.20 E2E_VM_USER=ubuntu ./scripts/e2e-k3s-junit-curl.sh
+E2E_VM_LIFECYCLE=external E2E_VM_HOST=192.168.64.20 E2E_VM_USER=ubuntu ./scripts/controlplane.sh e2e run k3s-junit-curl
 E2E_VM_LIFECYCLE=external E2E_VM_HOST=ci-k3s.example.com E2E_VM_USER=dev E2E_VM_HOME=/srv/dev E2E_KUBECONFIG_SERVER=https://ci-k3s.example.com:6443 ./scripts/controlplane.sh cli-test run host-platform
 ```
 
@@ -242,37 +242,37 @@ if [[ "${E2E_VM_LIFECYCLE:-multipass}" == "multipass" ]]; then
 fi
 ```
 
-### K3s JUnit Curl E2E (`scripts/e2e-k3s-junit-curl.sh`)
+### K3s JUnit Curl E2E (`scripts/controlplane.sh e2e run k3s-junit-curl`)
 
 Deploys the shared Helm stack on k3s, runs the curl-based API checks, then runs `K8sE2eTest` against the same installation.
 The script is a wrapper over `scripts/controlplane.sh e2e run k3s-junit-curl`.
 
 ```bash
-./scripts/e2e-k3s-junit-curl.sh
-./scripts/e2e-k3s-junit-curl.sh --no-cleanup-vm
+./scripts/controlplane.sh e2e run k3s-junit-curl
+./scripts/controlplane.sh e2e run k3s-junit-curl --no-cleanup-vm
 ```
 
-### Docker E2E (`scripts/e2e.sh`)
+### Docker E2E (`scripts/controlplane.sh e2e run docker`)
 
 Runs control-plane + function-runtime in local Docker containers using
 Testcontainers and RestAssured. No Kubernetes needed.
 The script is a wrapper over `scripts/controlplane.sh e2e run docker`.
 
 ```bash
-./scripts/e2e.sh
+./scripts/controlplane.sh e2e run docker
 ```
 
 The SDK parity suite `SdkExamplesE2eTest` now covers Java Spring SDK, Java lite SDK,
 and Go SDK example containers against the same control-plane flows.
 
-### Buildpack E2E (`scripts/e2e-buildpack.sh`)
+### Buildpack E2E (`scripts/controlplane.sh e2e run buildpack`)
 
 Same as Docker E2E but builds images using Cloud Native Buildpacks instead
 of Dockerfiles.
 The script is a wrapper over `scripts/controlplane.sh e2e run buildpack`.
 
 ```bash
-./scripts/e2e-buildpack.sh
+./scripts/controlplane.sh e2e run buildpack
 ```
 
 ### Kubernetes E2E (JUnit on k3s)
@@ -281,7 +281,7 @@ JUnit-based E2E now runs as the second verifier inside `k3s-junit-curl`, against
 
 ```bash
 scripts/controlplane.sh e2e run k3s-junit-curl
-./scripts/e2e-k3s-junit-curl.sh
+./scripts/controlplane.sh e2e run k3s-junit-curl
 ./gradlew k8sE2e
 ```
 
@@ -310,15 +310,14 @@ Preset-backed and scenario-backed deploy runs iterate the full resolved function
 scripts/controlplane.sh cli-test run deploy-host --function-preset demo-java --dry-run
 ```
 
-### Load Testing (`scripts/e2e-k3s-helm.sh` + `scripts/e2e-loadtest.sh`)
+### Load Testing (`scripts/controlplane.sh e2e run helm-stack` + `scripts/e2e-loadtest.sh`)
 
 Full Helm-based deployment with k6 load testing and Grafana dashboard.
 See [docs/e2e-tutorial.md](e2e-tutorial.md) for a detailed walkthrough.
-`scripts/e2e-k3s-helm.sh` is a wrapper over `scripts/controlplane.sh e2e run helm-stack`.
 `scripts/e2e-loadtest.sh` is a compatibility wrapper over `experiments/e2e-loadtest.sh`, not over `scripts/controlplane.sh loadtest run`.
 
 ```bash
-./scripts/e2e-k3s-helm.sh     # deploy nanofaas with Helm
+./scripts/controlplane.sh e2e run helm-stack     # deploy nanofaas with Helm
 ./scripts/e2e-loadtest.sh     # run k6 load tests + Grafana
 ./scripts/e2e-loadtest.sh --profile demo-java --dry-run
 ./scripts/e2e-loadtest.sh --help
@@ -462,9 +461,9 @@ open nanofaas-cli/build/reports/jacoco/test/html/index.html
 | CLI Stack E2E | Canonical VM-backed CLI stack validation | SSH key; Multipass optional for managed VM lifecycle | `scripts/controlplane.sh cli-test run cli-stack` |
 | Host CLI Platform E2E | Host CLI + Helm lifecycle on k3s VM | SSH key + Helm on host; Multipass optional | `scripts/controlplane.sh cli-test run host-platform` |
 | Host CLI Deploy E2E | Host-only deploy build+push+register | Docker + Python 3 | `scripts/controlplane.sh cli-test run deploy-host` |
-| K3s JUnit Curl E2E | Shared Helm deploy + curl API checks + `K8sE2eTest` | SSH; Multipass optional for managed VM lifecycle | `./scripts/e2e-k3s-junit-curl.sh` |
-| Docker E2E | Core flow | Docker | `./scripts/e2e.sh` |
-| Buildpack E2E | Core flow (buildpack) | Docker | `./scripts/e2e-buildpack.sh` |
-| K8s E2E (JUnit) | Control-plane on k3s | SSH; Multipass optional for managed VM lifecycle | `./scripts/e2e-k3s-junit-curl.sh` or `./gradlew k8sE2e` |
-| Load test | Performance | SSH + k6; Multipass optional for managed VM lifecycle | `./scripts/e2e-k3s-helm.sh && ./scripts/e2e-loadtest.sh` |
+| K3s JUnit Curl E2E | Shared Helm deploy + curl API checks + `K8sE2eTest` | SSH; Multipass optional for managed VM lifecycle | `./scripts/controlplane.sh e2e run k3s-junit-curl` |
+| Docker E2E | Core flow | Docker | `./scripts/controlplane.sh e2e run docker` |
+| Buildpack E2E | Core flow (buildpack) | Docker | `./scripts/controlplane.sh e2e run buildpack` |
+| K8s E2E (JUnit) | Control-plane on k3s | SSH; Multipass optional for managed VM lifecycle | `./scripts/controlplane.sh e2e run k3s-junit-curl` or `./gradlew k8sE2e` |
+| Load test | Performance | SSH + k6; Multipass optional for managed VM lifecycle | `./scripts/controlplane.sh e2e run helm-stack && ./scripts/e2e-loadtest.sh` |
 | Control-plane module matrix | Compile-time module compatibility | JDK 21 | `./scripts/test-control-plane-module-combinations.sh` |

--- a/experiments/e2e-memory-ab.sh
+++ b/experiments/e2e-memory-ab.sh
@@ -202,7 +202,7 @@ run_deploy_case() {
         HOST_REBUILD_IMAGES="${HOST_REBUILD_IMAGES}" \
         LOADTEST_WORKLOADS="${LOADTEST_WORKLOADS}" \
         LOADTEST_RUNTIMES="${LOADTEST_RUNTIMES}" \
-        bash "${PROJECT_ROOT}/scripts/e2e-k3s-helm.sh"
+        bash "${PROJECT_ROOT}/scripts/controlplane.sh" e2e run helm-stack
     ) > "${deploy_log}" 2>&1
 }
 

--- a/experiments/e2e-runtime-ab.sh
+++ b/experiments/e2e-runtime-ab.sh
@@ -125,7 +125,7 @@ run_deploy_case() {
         LOADTEST_WORKLOADS="${LOADTEST_WORKLOADS}" \
         LOADTEST_RUNTIMES="${LOADTEST_RUNTIMES}" \
         CONTROL_PLANE_RUST_DIR="${CONTROL_PLANE_RUST_DIR:-}" \
-        bash "${PROJECT_ROOT}/scripts/e2e-k3s-helm.sh"
+        bash "${PROJECT_ROOT}/scripts/controlplane.sh" e2e run helm-stack
     ) > "${deploy_log}" 2>&1
 }
 

--- a/scripts/control-plane-build.sh
+++ b/scripts/control-plane-build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh <build|run|image|native|test|inspect|matrix> ...`.
-exec "$(dirname "$0")/controlplane.sh" "$@"

--- a/scripts/control-plane-building.sh
+++ b/scripts/control-plane-building.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh <building|run|image|native|test|inspect|matrix> ...`.
-exec "$(dirname "$0")/controlplane.sh" "$@"

--- a/scripts/controlplane-tool.sh
+++ b/scripts/controlplane-tool.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh tui ...`.
-exec "$(dirname "$0")/controlplane.sh" tui "$@"

--- a/scripts/e2e-all.sh
+++ b/scripts/e2e-all.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh e2e all ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e all "$@"

--- a/scripts/e2e-buildpack.sh
+++ b/scripts/e2e-buildpack.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh e2e run buildpack ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e run buildpack "$@"

--- a/scripts/e2e-container-local.sh
+++ b/scripts/e2e-container-local.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh e2e run container-local ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e run container-local "$@"

--- a/scripts/e2e-k3s-helm.sh
+++ b/scripts/e2e-k3s-helm.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh e2e run helm-stack ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e run helm-stack "$@"

--- a/scripts/e2e-k3s-junit-curl.sh
+++ b/scripts/e2e-k3s-junit-curl.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Convenience wrapper. Prefer `scripts/controlplane.sh e2e run k3s-junit-curl ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e run k3s-junit-curl "$@"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-# Compatibility wrapper. Prefer `scripts/controlplane.sh e2e run docker ...`.
-exec "$(dirname "$0")/controlplane.sh" e2e run docker "$@"

--- a/tooling/controlplane_tui/README.md
+++ b/tooling/controlplane_tui/README.md
@@ -30,9 +30,9 @@ This app is implemented in Python and managed with `uv`.
 From repository root:
 
 ```bash
-scripts/controlplane-tool.sh --help
-scripts/controlplane-tool.sh --profile-name dev
-scripts/controlplane-tool.sh --profile-name dev --use-saved-profile
+scripts/controlplane.sh tui --help
+scripts/controlplane.sh tui --profile-name dev
+scripts/controlplane.sh tui --profile-name dev --use-saved-profile
 ```
 
 ## CLI options


### PR DESCRIPTION
## Summary

First slice of the bash-elimination effort ("one way to do things"): delete the 9 compatibility-wrapper scripts and point every consumer at the single canonical launcher `scripts/controlplane.sh`.

### Deleted (9 pure `exec controlplane.sh ...` aliases)
`e2e.sh`, `e2e-all.sh`, `e2e-k3s-junit-curl.sh`, `e2e-k3s-helm.sh`, `e2e-container-local.sh`, `e2e-buildpack.sh`, `control-plane-build.sh`, `control-plane-building.sh`, `controlplane-tool.sh`.

### Consumers repointed (before deleting)
- `build.gradle` — `k8sE2eVm` task → `scripts/controlplane.sh e2e run k3s-junit-curl`
- `control-plane/build.gradle` — `k8sE2eTest` task → same (a second consumer not in the spec, caught by the final grep)
- `experiments/e2e-memory-ab.sh`, `experiments/e2e-runtime-ab.sh` (band-C, kept) — their `e2e-k3s-helm.sh` call → `controlplane.sh e2e run helm-stack`
- Docs: `GEMINI.md`, `AGENTS.md`, `docs/testing.md`, `tooling/controlplane_tui/README.md`

### Kept
- The launchers `scripts/controlplane.sh` and `scripts/fn-init.sh`.
- Band-B scripts (`e2e-loadtest.sh`, `build-push-images.sh`, `native-build.sh`, `k6/run-all.sh`, `experiments/run.sh`) and band-C experiment scripts — ported in later slices.
- Historical plan archives (`docs/plans/*`, `docs/superpowers/*`) and frozen experiment snapshots — intentionally untouched.

## Test Plan
- [x] `bash -n` on the two edited experiment scripts → OK
- [x] `./gradlew help --task k8sE2eVm` and `:control-plane:tasks` resolve with the new `commandLine`
- [x] `bash scripts/controlplane.sh --help` → controlplane-tool usage
- [x] Final grep: no live operational reference to any deleted wrapper (excluding historical archives/snapshots)
- [x] `e2e-loadtest.sh` (band B) references preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
