### PR TITLE
refactor: decouple verification planners from controlplane-tool (inject commands via context)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-decouple-verification-commands.md
+++ b/docs/superpowers/plans/2026-06-03-decouple-verification-commands.md
@@ -1,0 +1,270 @@
+# Decouple verification planners from controlplane-tool (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the three `workflow_tasks` verification planners read the controlplane-tool command from the execution context instead of hard-coding it, and have controlplane inject those commands — so the library no longer knows how to invoke controlplane.
+
+**Architecture:** Add three neutral command fields to the library's `ScenarioExecutionContext` dataclass; controlplane (which builds the context) populates them with its controlplane-tool argv; the three planners read `context.*_command` (a guard raises if unset). Ordered so every task leaves BOTH suites green: (1) add inert context fields, (2) controlplane injects them (planners still hard-code — inert), (3) flip the planners to read the injected commands + update tests.
+
+**Tech Stack:** Python, dataclasses, pytest, uv.
+
+**Commands:** library `uv run --project tools/workflow-tasks pytest <path>`; controlplane `uv run --project tools/controlplane pytest <path>`. Branch: `refactor/wt-decouple-verification-commands` (created). Spec: `docs/superpowers/specs/2026-06-03-decouple-verification-commands-design.md`. Baseline both suites green.
+
+**Verified facts:**
+- `ScenarioExecutionContext` = frozen dataclass in `tools/workflow-tasks/src/workflow_tasks/components/context.py` (fields end with `manifest_path`, `release`, `loadgen_vm_request`, all with defaults).
+- The 3 planners are in `tools/workflow-tasks/src/workflow_tasks/components/verification.py`; their current argv is hard-coded (see Task 3).
+- Library test: `tools/workflow-tasks/tests/components/test_verification.py` builds the context via a `_ctx(...)` helper.
+- Controlplane builds the context at exactly 2 src sites: `scenario/components/environment.py:61` (factory, has `repo_root`) and `infra/vm/vm_cluster_workflows.py:116` (a "legacy" context, has `vm.repo_root`). `two_vm_loadtest._loadgen_context` uses `dataclasses.replace` (carries new fields automatically).
+
+---
+
+### Task 1: Add inert command fields to the context
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/components/context.py`
+
+- [ ] **Step 1: Add the three fields**
+
+At the end of the `ScenarioExecutionContext` dataclass (after `loadgen_vm_request`), add:
+```python
+    # Controlplane-tool verification commands, injected by the controlplane context
+    # factory. Empty by default so this library module stays controlplane-agnostic.
+    k3s_curl_verify_command: tuple[str, ...] = ()
+    loadtest_run_command: tuple[str, ...] = ()
+    autoscaling_command: tuple[str, ...] = ()
+```
+
+- [ ] **Step 2: Both suites stay green (inert change)**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks -q 2>&1 | tail -3`
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests -q 2>&1 | tail -3`
+Expected: both pass (the fields are unused so far).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/components/context.py
+git commit -m "feat(workflow-tasks): add injectable verification-command fields to context"
+```
+
+---
+
+### Task 2: Controlplane defines and injects the commands
+
+**Files:**
+- Create: `tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py`
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/components/environment.py`
+- Modify: `tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py`
+
+- [ ] **Step 1: Create the command builders**
+
+Create `tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py`:
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def k3s_curl_verify_command() -> tuple[str, ...]:
+    return ("python", "-m", "controlplane_tool.e2e.k3s_curl_runner", "verify-existing-stack")
+
+
+def loadtest_run_command() -> tuple[str, ...]:
+    return ("uv", "run", "--project", "tools/controlplane", "--locked",
+            "controlplane-tool", "loadtest", "run")
+
+
+def autoscaling_command(repo_root: Path) -> tuple[str, ...]:
+    return ("uv", "run", "--project", str(Path(repo_root) / "tools" / "controlplane"),
+            "--locked", "python", str(Path(repo_root) / "experiments" / "autoscaling.py"))
+```
+(These argv are copied verbatim from the planners' current hard-coded values so the command snapshots do not change.)
+
+- [ ] **Step 2: Inject in the factory (`environment.py`)**
+
+In `tools/controlplane/src/controlplane_tool/scenario/components/environment.py`, add the import near the top:
+```python
+from controlplane_tool.scenario.components import verification_commands as _vc
+```
+In the `ScenarioExecutionContext(...)` construction (the `return ScenarioExecutionContext(` block around line 61), add the three fields (after `loadgen_vm_request=...`):
+```python
+        k3s_curl_verify_command=_vc.k3s_curl_verify_command(),
+        loadtest_run_command=_vc.loadtest_run_command(),
+        autoscaling_command=_vc.autoscaling_command(repo_root),
+```
+(`repo_root` is already in scope in this factory.)
+
+- [ ] **Step 3: Inject in `vm_cluster_workflows.py`**
+
+In `tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py`, add the import near the top:
+```python
+from controlplane_tool.scenario.components import verification_commands as _vc
+```
+In the `scenario_context = ScenarioExecutionContext(` block (around line 116), add after `cleanup_vm=True,`:
+```python
+        k3s_curl_verify_command=_vc.k3s_curl_verify_command(),
+        loadtest_run_command=_vc.loadtest_run_command(),
+        autoscaling_command=_vc.autoscaling_command(vm.repo_root),
+```
+
+- [ ] **Step 4: Both suites stay green (still inert — planners ignore the fields)**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests -q 2>&1 | tail -3` → pass.
+Run: `uv run --project tools/controlplane lint-imports --config tools/controlplane/.importlinter` → 0 broken.
+Run: `uv run --project tools/controlplane ruff check tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py tools/controlplane/src/controlplane_tool/scenario/components/environment.py tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py tools/controlplane/src/controlplane_tool/scenario/components/environment.py tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py
+git commit -m "feat(controlplane): define + inject verification commands into the scenario context"
+```
+
+---
+
+### Task 3: Flip the planners to read the injected commands
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/components/verification.py`
+- Modify: `tools/workflow-tasks/tests/components/test_verification.py`
+
+- [ ] **Step 1: Update the library tests first (they will fail)**
+
+In `tools/workflow-tasks/tests/components/test_verification.py`, extend the `_ctx(...)` helper to inject test commands, and update/add the planner assertions.
+
+Change `_ctx` to accept the commands (with non-empty test defaults):
+```python
+def _ctx(*, manifest: Path | None = None) -> ScenarioExecutionContext:
+    return ScenarioExecutionContext(
+        repo_root=Path("/repo"),
+        scenario_name="k3s-junit-curl",
+        runtime="java",
+        namespace="nf",
+        local_registry="localhost:5000",
+        resolved_scenario=_RS(namespace="nf", functions=[]),
+        vm_request=VmRequest(lifecycle="multipass", name="nanofaas-e2e", user="ubuntu"),
+        cleanup_vm=True,
+        manifest_path=manifest,
+        k3s_curl_verify_command=("verify", "k3s"),
+        loadtest_run_command=("loadtest", "go"),
+        autoscaling_command=("autoscale", "go"),
+    )
+```
+Replace the existing `test_run_k3s_curl_checks_runs_controlplane_runner` body to assert the INJECTED command, and add loadtest/autoscaling + empty-guard tests:
+```python
+def test_run_k3s_curl_checks_uses_injected_command() -> None:
+    ops = ver.plan_run_k3s_curl_checks(_ctx())
+    assert ops[0].argv == ("verify", "k3s")
+
+
+def test_loadtest_run_uses_injected_command() -> None:
+    ops = ver.plan_loadtest_run(_ctx())
+    assert ops[0].argv == ("loadtest", "go")
+    assert ops[0].execution_target == "vm"
+
+
+def test_autoscaling_uses_injected_command() -> None:
+    ops = ver.plan_autoscaling_experiment(_ctx())
+    assert ops[0].argv == ("autoscale", "go")
+
+
+def test_planner_raises_when_command_not_injected() -> None:
+    import dataclasses
+    import pytest
+
+    ctx = dataclasses.replace(_ctx(), loadtest_run_command=())
+    with pytest.raises(ValueError):
+        ver.plan_loadtest_run(ctx)
+```
+(If the old `test_run_k3s_curl_checks_runs_controlplane_runner` asserted the hard-coded `controlplane_tool` argv, delete it — it is replaced by `test_run_k3s_curl_checks_uses_injected_command`.)
+
+- [ ] **Step 2: Run the library tests — they fail**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/components/test_verification.py -q`
+Expected: FAIL (planners still return the hard-coded argv, not the injected one).
+
+- [ ] **Step 3: Rewrite the three planners to read the context**
+
+In `tools/workflow-tasks/src/workflow_tasks/components/verification.py`, add a guard helper near the top (after the imports / existing helpers):
+```python
+def _require_command(command: tuple[str, ...], name: str) -> tuple[str, ...]:
+    if not command:
+        raise ValueError(f"context.{name} was not provided by the context factory")
+    return command
+```
+Replace the three planners:
+```python
+def plan_run_k3s_curl_checks(context: ScenarioExecutionContext) -> tuple[ScenarioOperation, ...]:
+    return (
+        RemoteCommandOperation(
+            operation_id="tests.run_k3s_curl_checks",
+            summary="Run k3s-junit-curl verification",
+            argv=_require_command(context.k3s_curl_verify_command, "k3s_curl_verify_command"),
+            env=_frozen_env(),
+        ),
+    )
+
+
+def plan_loadtest_run(context: ScenarioExecutionContext) -> tuple[ScenarioOperation, ...]:
+    env = dict(_managed_vm_env(context))
+    remote_manifest_path = _remote_manifest_path(context)
+    if remote_manifest_path is not None:
+        env["NANOFAAS_SCENARIO_PATH"] = remote_manifest_path
+    return (
+        RemoteCommandOperation(
+            operation_id="loadtest.run",
+            summary="Run k6 loadtest via controlplane runner",
+            argv=_require_command(context.loadtest_run_command, "loadtest_run_command"),
+            env=_frozen_env(env),
+            execution_target="vm",
+        ),
+    )
+
+
+def plan_autoscaling_experiment(context: ScenarioExecutionContext) -> tuple[ScenarioOperation, ...]:
+    env = dict(_managed_vm_env(context))
+    if context.manifest_path is not None:
+        env["NANOFAAS_SCENARIO_PATH"] = str(context.manifest_path)
+    return (
+        RemoteCommandOperation(
+            operation_id="experiments.autoscaling",
+            summary="Run autoscaling experiment (Python)",
+            argv=_require_command(context.autoscaling_command, "autoscaling_command"),
+            env=_frozen_env(env),
+        ),
+    )
+```
+(Removes the `controlplane_tool_project = ...` lines and the hard-coded argv tuples. `plan_run_k8s_junit` and all other planners are unchanged. If `Path` is now unused in the file after removing the autoscaling `Path(...)` usage, leave it if other code uses it; if ruff flags it as unused, remove the import.)
+
+- [ ] **Step 4: Run the library tests — they pass**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/components/test_verification.py -q` → pass.
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks -q 2>&1 | tail -3` → all pass, coverage ≥ 90%.
+
+- [ ] **Step 5: Controlplane suite is now green again (commands injected in Task 2)**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests -q 2>&1 | tail -3`
+Expected: 0 failures. The loadtest/k3s-curl/autoscaling command snapshots match because controlplane injects the same argv. If a snapshot mismatches, compare the injected `verification_commands.*` argv against the expected snapshot and reconcile the command builder (do NOT change behavior).
+
+- [ ] **Step 6: Verify the invocation coupling is gone + lint**
+
+Run: `grep -n "controlplane_tool\|controlplane-tool" tools/workflow-tasks/src/workflow_tasks/components/verification.py`
+Expected: EMPTY (no controlplane invocation argv left; the only remaining controlplane string anywhere in the library is the `tools/controlplane/runs/manifests` path in `_remote_manifest_path`, which is level-B and out of scope — confirm it is the ONLY remaining hit via `grep -rn "controlplane" tools/workflow-tasks/src/workflow_tasks/components/verification.py`).
+Run: `uv run --project tools/workflow-tasks ruff check tools/workflow-tasks/src/workflow_tasks/components/verification.py` → clean.
+Run: `uv run --project tools/workflow-tasks lint-imports --config tools/workflow-tasks/.importlinter` → 0 broken.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/components/verification.py tools/workflow-tasks/tests/components/test_verification.py
+git commit -m "refactor(workflow-tasks): verification planners read injected commands (no controlplane-tool invocation)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** context fields → Task 1; controlplane command builders + injection at both construction sites → Task 2; planners read context + guard + tests → Task 3; snapshots unchanged → Task 3 Step 5 (same argv injected); invocation coupling gone → Task 3 Step 6; level-B path strings explicitly left → noted. ✓
+- **Ordering:** every task leaves both suites green — T1 inert (unused fields), T2 inert (planners still hard-code), T3 flips + tests in lockstep. The guard's empty-raise can only trigger if a context isn't injected; both src construction sites are injected in T2, and `_loadgen_context` uses `replace` (carries the fields). ✓
+- **Placeholder scan:** none — full code for the fields, the 3 command builders, both injection edits, the guard, the 3 rewritten planners, and every test. Exact grep/run commands with expected output.
+- **Type consistency:** field names `k3s_curl_verify_command` / `loadtest_run_command` / `autoscaling_command` are identical across the context dataclass (T1), the controlplane injection (T2), the planners' `_require_command(context.<name>, "<name>")` (T3), and the tests. The builder `autoscaling_command(repo_root)` takes `repo_root`; both call sites pass a real repo root (`repo_root` / `vm.repo_root`). ✓

--- a/docs/superpowers/specs/2026-06-03-decouple-verification-commands-design.md
+++ b/docs/superpowers/specs/2026-06-03-decouple-verification-commands-design.md
@@ -1,0 +1,112 @@
+# Decouple verification planners from controlplane-tool (inject commands via context) — Design
+
+**Status:** approved (Approach A), pending implementation plan
+**Date:** 2026-06-03
+
+## Goal
+
+Remove the runtime coupling where three `workflow_tasks` verification components hard-code
+commands that invoke `controlplane-tool` as a subprocess. The library should no longer
+**know how to invoke controlplane** — the command is injected by controlplane via the
+execution context.
+
+## The coupling (level A — invocations)
+
+In `workflow_tasks/components/verification.py`, three planners build argv that launch
+controlplane-tool / controlplane modules:
+- `plan_run_k3s_curl_checks` → `("python", "-m", "controlplane_tool.e2e.k3s_curl_runner", "verify-existing-stack")`
+- `plan_loadtest_run` → `("uv", "run", "--project", "tools/controlplane", "--locked", "controlplane-tool", "loadtest", "run")`
+- `plan_autoscaling_experiment` → `("uv", "run", "--project", str(repo_root/"tools/controlplane"), "--locked", "python", str(repo_root/"experiments/autoscaling.py"))`
+
+These are strings (argv), not Python imports, so import-linter doesn't catch them — but
+those components only work inside a repo that has `controlplane-tool` at `tools/controlplane`.
+
+**Out of scope (level B — path/layout strings):** `_remote_manifest_path`'s
+`tools/controlplane/runs/manifests` fallback (used by the *kept* `plan_run_k8s_junit`),
+and the rsync-exclude / image-cache path strings in `vm/multipass.py` and `images.py`.
+These are nanofaas repo-layout conventions — deliberate nanofaas-isms, left as-is
+(consistent with prior scope decisions).
+
+## Approach: inject the commands via the context (Approach A)
+
+`ScenarioExecutionContext` is a frozen dataclass defined in the library
+(`workflow_tasks/components/context.py`) and **constructed by controlplane** (the factory
+`resolve_scenario_environment` in `scenario/components/environment.py`). The planners
+already receive this context. So:
+
+1. **Library — add three neutral command fields to `ScenarioExecutionContext`** (empty-tuple
+   defaults, so the library stays controlplane-agnostic):
+   ```python
+   k3s_curl_verify_command: tuple[str, ...] = ()
+   loadtest_run_command: tuple[str, ...] = ()
+   autoscaling_command: tuple[str, ...] = ()
+   ```
+
+2. **Library — the three planners read the injected command** instead of hard-coding it.
+   A small guard raises a clear error if the factory forgot to provide it (so an empty
+   default never silently produces a broken empty argv):
+   ```python
+   def _require_command(command: tuple[str, ...], name: str) -> tuple[str, ...]:
+       if not command:
+           raise ValueError(f"context.{name} was not provided by the context factory")
+       return command
+   ```
+   - `plan_run_k3s_curl_checks`: `argv=_require_command(context.k3s_curl_verify_command, "k3s_curl_verify_command")`
+   - `plan_loadtest_run`: `argv=_require_command(context.loadtest_run_command, "loadtest_run_command")` (the `env` built from the existing helpers is unchanged)
+   - `plan_autoscaling_experiment`: `argv=_require_command(context.autoscaling_command, "autoscaling_command")` (env unchanged)
+   The `controlplane_tool_project = "tools/controlplane"` lines and the hard-coded argv are removed.
+
+3. **Controlplane — define the commands and inject them when building the context.** Add a
+   small module `controlplane_tool/scenario/components/verification_commands.py`:
+   ```python
+   def k3s_curl_verify_command() -> tuple[str, ...]:
+       return ("python", "-m", "controlplane_tool.e2e.k3s_curl_runner", "verify-existing-stack")
+
+   def loadtest_run_command() -> tuple[str, ...]:
+       return ("uv", "run", "--project", "tools/controlplane", "--locked", "controlplane-tool", "loadtest", "run")
+
+   def autoscaling_command(repo_root: Path) -> tuple[str, ...]:
+       return ("uv", "run", "--project", str(repo_root / "tools" / "controlplane"),
+               "--locked", "python", str(repo_root / "experiments" / "autoscaling.py"))
+   ```
+   (Exact argv preserved verbatim from the originals so command snapshots don't change —
+   note `loadtest` uses the relative `tools/controlplane`, `autoscaling` uses absolute
+   `repo_root/...`, matching today's behavior.)
+
+4. **Controlplane — populate the three fields at the construction sites.** Only two src
+   sites build the context directly: `scenario/components/environment.py:61` (the main
+   factory — has `repo_root`) and `infra/vm/vm_cluster_workflows.py:116`. Set the three
+   fields there from the command builders. The derived `two_vm_loadtest._loadgen_context`
+   uses `dataclasses.replace`, so it carries the new fields automatically.
+
+## Boundary outcome
+
+- The library `verification.py` no longer contains any `controlplane-tool` / `controlplane_tool`
+  **invocation** argv. (The `_remote_manifest_path` `tools/controlplane/runs/manifests`
+  path string remains — level B, acknowledged.)
+- Controlplane owns the controlplane-tool commands and injects them. This matches the
+  established boundary ("library = how to build the step + env; controlplane = which
+  command to run") and the `cli.py`-stays-in-controlplane precedent.
+
+## Testing
+
+- **Library:** update `tests/components/test_verification.py` (or wherever those 3 planners
+  are tested) so the test context provides the command fields, and assert the planner argv
+  equals the injected command. Add a test that an empty command raises `ValueError`.
+  Coverage gate 90 holds.
+- **Controlplane:** the scenario oracle/snapshot tests that pin the loadtest/k3s-curl/
+  autoscaling commands (e.g. `test_*_workflow.py`, `test_two_vm_loadtest_*`,
+  `test_scenario_recipes`/`test_scenario_component_library` if they assert these argv) must
+  still pass UNCHANGED, because controlplane injects the same commands. If any snapshot
+  asserts the command, confirm it still matches; do not change the expected argv.
+- **Guard:** a library test asserting `grep`-style that `verification.py` no longer builds a
+  `controlplane_tool`/`controlplane-tool` invocation — OR simply rely on the planner tests
+  reading from context. (Lightweight: assert `plan_loadtest_run` of a context with empty
+  `loadtest_run_command` raises.)
+- `lint-imports` both projects 0 broken; both suites green; `ruff` clean.
+
+## Success criteria
+
+- The three planners produce argv taken from `context.*_command`; an unset command raises.
+- Controlplane defines + injects the three commands; existing command snapshots unchanged.
+- `workflow_tasks/components/verification.py` has no `controlplane-tool` invocation argv left.

--- a/tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py
+++ b/tools/controlplane/src/controlplane_tool/infra/vm/vm_cluster_workflows.py
@@ -14,6 +14,7 @@ from workflow_tasks.components import helm as helm_components
 from workflow_tasks.components import images as image_components
 from workflow_tasks.components import namespace as namespace_components
 from controlplane_tool.scenario.components.environment import ScenarioExecutionContext
+from controlplane_tool.scenario.components import verification_commands as _vc
 from workflow_tasks.components.operations import RemoteCommandOperation, ScenarioOperation
 from controlplane_tool.scenario.scenario_models import ResolvedScenario
 from workflow_tasks.shell import ShellExecutionResult
@@ -122,6 +123,9 @@ def build_vm_cluster_prelude_plan(
         resolved_scenario=resolved_scenario,
         vm_request=vm_request,
         cleanup_vm=True,
+        k3s_curl_verify_command=_vc.k3s_curl_verify_command(),
+        loadtest_run_command=_vc.loadtest_run_command(),
+        autoscaling_command=_vc.autoscaling_command(vm.repo_root),
     )
     remote_dir = vm.remote_project_dir(vm_request)
     bootstrap_plan = {

--- a/tools/controlplane/src/controlplane_tool/scenario/components/environment.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/components/environment.py
@@ -13,6 +13,7 @@ from controlplane_tool.scenario.scenario_defaults import (
 from controlplane_tool.scenario.components.recipes import build_scenario_recipe
 from controlplane_tool.infra.vm.vm_models import VmRequest
 from workflow_tasks.components.context import ScenarioExecutionContext
+from controlplane_tool.scenario.components import verification_commands as _vc
 
 
 def default_managed_vm_request() -> VmRequest:
@@ -70,4 +71,7 @@ def resolve_scenario_environment(
         manifest_path=manifest_path,
         release=effective_release,
         loadgen_vm_request=getattr(request, "loadgen_vm", None),
+        k3s_curl_verify_command=_vc.k3s_curl_verify_command(),
+        loadtest_run_command=_vc.loadtest_run_command(),
+        autoscaling_command=_vc.autoscaling_command(repo_root),
     )

--- a/tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/components/verification_commands.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def k3s_curl_verify_command() -> tuple[str, ...]:
+    return ("python", "-m", "controlplane_tool.e2e.k3s_curl_runner", "verify-existing-stack")
+
+
+def loadtest_run_command() -> tuple[str, ...]:
+    return ("uv", "run", "--project", "tools/controlplane", "--locked",
+            "controlplane-tool", "loadtest", "run")
+
+
+def autoscaling_command(repo_root: Path) -> tuple[str, ...]:
+    return ("uv", "run", "--project", str(Path(repo_root) / "tools" / "controlplane"),
+            "--locked", "python", str(Path(repo_root) / "experiments" / "autoscaling.py"))

--- a/tools/workflow-tasks/src/workflow_tasks/components/context.py
+++ b/tools/workflow-tasks/src/workflow_tasks/components/context.py
@@ -48,3 +48,8 @@ class ScenarioExecutionContext:
     manifest_path: Path | None = None
     release: str | None = None
     loadgen_vm_request: VmRequest | None = None
+    # Controlplane-tool verification commands, injected by the controlplane context
+    # factory. Empty by default so this library module stays controlplane-agnostic.
+    k3s_curl_verify_command: tuple[str, ...] = ()
+    loadtest_run_command: tuple[str, ...] = ()
+    autoscaling_command: tuple[str, ...] = ()

--- a/tools/workflow-tasks/src/workflow_tasks/components/verification.py
+++ b/tools/workflow-tasks/src/workflow_tasks/components/verification.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from pathlib import Path
 from types import MappingProxyType
 
 from workflow_tasks.components.platform_commands import platform_status_command
@@ -12,6 +11,12 @@ from workflow_tasks.components.remote_script import k8s_e2e_test_vm_script
 
 def _frozen_env(env: Mapping[str, str] | None = None) -> Mapping[str, str]:
     return MappingProxyType(dict(env or {}))
+
+
+def _require_command(command: tuple[str, ...], name: str) -> tuple[str, ...]:
+    if not command:
+        raise ValueError(f"context.{name} was not provided by the context factory")
+    return command
 
 
 def _namespace(context: ScenarioExecutionContext) -> str:
@@ -117,7 +122,7 @@ def plan_run_k3s_curl_checks(context: ScenarioExecutionContext) -> tuple[Scenari
         RemoteCommandOperation(
             operation_id="tests.run_k3s_curl_checks",
             summary="Run k3s-junit-curl verification",
-            argv=("python", "-m", "controlplane_tool.e2e.k3s_curl_runner", "verify-existing-stack"),
+            argv=_require_command(context.k3s_curl_verify_command, "k3s_curl_verify_command"),
             env=_frozen_env(),
         ),
     )
@@ -145,7 +150,6 @@ def plan_run_k8s_junit(context: ScenarioExecutionContext) -> tuple[ScenarioOpera
 
 
 def plan_loadtest_run(context: ScenarioExecutionContext) -> tuple[ScenarioOperation, ...]:
-    controlplane_tool_project = "tools/controlplane"
     env = dict(_managed_vm_env(context))
     remote_manifest_path = _remote_manifest_path(context)
     if remote_manifest_path is not None:
@@ -154,16 +158,7 @@ def plan_loadtest_run(context: ScenarioExecutionContext) -> tuple[ScenarioOperat
         RemoteCommandOperation(
             operation_id="loadtest.run",
             summary="Run k6 loadtest via controlplane runner",
-            argv=(
-                "uv",
-                "run",
-                "--project",
-                str(controlplane_tool_project),
-                "--locked",
-                "controlplane-tool",
-                "loadtest",
-                "run",
-            ),
+            argv=_require_command(context.loadtest_run_command, "loadtest_run_command"),
             env=_frozen_env(env),
             execution_target="vm",
         ),
@@ -171,7 +166,6 @@ def plan_loadtest_run(context: ScenarioExecutionContext) -> tuple[ScenarioOperat
 
 
 def plan_autoscaling_experiment(context: ScenarioExecutionContext) -> tuple[ScenarioOperation, ...]:
-    controlplane_tool_project = Path(context.repo_root) / "tools" / "controlplane"
     env = dict(_managed_vm_env(context))
     if context.manifest_path is not None:
         env["NANOFAAS_SCENARIO_PATH"] = str(context.manifest_path)
@@ -179,15 +173,7 @@ def plan_autoscaling_experiment(context: ScenarioExecutionContext) -> tuple[Scen
         RemoteCommandOperation(
             operation_id="experiments.autoscaling",
             summary="Run autoscaling experiment (Python)",
-            argv=(
-                "uv",
-                "run",
-                "--project",
-                str(controlplane_tool_project),
-                "--locked",
-                "python",
-                str(Path(context.repo_root) / "experiments" / "autoscaling.py"),
-            ),
+            argv=_require_command(context.autoscaling_command, "autoscaling_command"),
             env=_frozen_env(env),
         ),
     )

--- a/tools/workflow-tasks/tests/components/test_verification.py
+++ b/tools/workflow-tasks/tests/components/test_verification.py
@@ -25,6 +25,9 @@ def _ctx(*, manifest: Path | None = None) -> ScenarioExecutionContext:
         vm_request=VmRequest(lifecycle="multipass", name="nanofaas-e2e", user="ubuntu"),
         cleanup_vm=True,
         manifest_path=manifest,
+        k3s_curl_verify_command=("verify", "k3s"),
+        loadtest_run_command=("loadtest", "go"),
+        autoscaling_command=("autoscale", "go"),
     )
 
 
@@ -43,7 +46,26 @@ def test_run_k8s_junit_embeds_gradle_e2e_script() -> None:
     assert "k8s-deployment-provider:test" in rendered
 
 
-def test_run_k3s_curl_checks_runs_controlplane_runner() -> None:
+def test_run_k3s_curl_checks_uses_injected_command() -> None:
     ops = ver.plan_run_k3s_curl_checks(_ctx())
-    rendered = " ".join(ops[0].argv)
-    assert "controlplane_tool.e2e.k3s_curl_runner" in rendered
+    assert ops[0].argv == ("verify", "k3s")
+
+
+def test_loadtest_run_uses_injected_command() -> None:
+    ops = ver.plan_loadtest_run(_ctx())
+    assert ops[0].argv == ("loadtest", "go")
+    assert ops[0].execution_target == "vm"
+
+
+def test_autoscaling_uses_injected_command() -> None:
+    ops = ver.plan_autoscaling_experiment(_ctx())
+    assert ops[0].argv == ("autoscale", "go")
+
+
+def test_planner_raises_when_command_not_injected() -> None:
+    import dataclasses
+    import pytest
+
+    ctx = dataclasses.replace(_ctx(), loadtest_run_command=())
+    with pytest.raises(ValueError):
+        ver.plan_loadtest_run(ctx)


### PR DESCRIPTION
## Summary

Removes the runtime coupling where three `workflow_tasks` verification components hard-coded commands that invoke `controlplane-tool` as a subprocess. The library no longer knows how to invoke controlplane — controlplane **injects** the commands via the execution context (Approach A, the user's "pass it in from outside").

### How
- **Library** (`components/context.py`): added three neutral fields to `ScenarioExecutionContext` — `k3s_curl_verify_command`, `loadtest_run_command`, `autoscaling_command` (empty-tuple defaults, so the module stays controlplane-agnostic).
- **Controlplane** (`scenario/components/verification_commands.py` + injection in `environment.py` and `vm_cluster_workflows.py`): defines the controlplane-tool argv (verbatim from the old hard-coded values) and populates the three context fields at the two construction sites. `two_vm_loadtest._loadgen_context` carries them via `dataclasses.replace`.
- **Library** (`components/verification.py`): the three planners now read `context.*_command` (a `_require_command` guard raises a clear error if a command wasn't injected); the `controlplane_tool`/`controlplane-tool` invocation argv are gone.

Ordered so every commit kept both suites green: add inert fields → inject (still inert) → flip the planners + tests.

### Scope
This closes the **invocation** coupling (the "call the chef next door"). The remaining nanofaas repo-layout *path strings* (`tools/controlplane/runs/manifests` used by the kept `plan_run_k8s_junit`, rsync excludes) are deliberate nanofaas-isms, left as-is — consistent with prior scope decisions. The library remains nanofaas-opinionated by design.

## Test Plan
- [x] `uv run --project tools/workflow-tasks pytest` → 361 passed, coverage 91.50%; new tests prove planners echo the injected command and the guard raises when unset
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests` → 1125 passed (command snapshots unchanged — same argv injected)
- [x] `grep "controlplane_tool|controlplane-tool" verification.py` → empty (no invocation argv left)
- [x] `lint-imports` both projects → 0 broken (incl. `workflow_tasks must not import controlplane_tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
