### PR TITLE
fix(two-vm-loadtest): full provisioning pipeline + robust k6 install

### DIFF
--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
@@ -13,9 +13,10 @@ from workflow_tasks import (
     RunK6,
     TimeWindow,
     Workflow,
-    WriteK6Report,
     workflow_step,
+    WriteK6Report,
 )
+from workflow_tasks.components.models import ScenarioRecipe
 from workflow_tasks.loadtest.models import K6Config, K6Stage
 from workflow_tasks.vm.models import VmConfig
 
@@ -28,9 +29,13 @@ from controlplane_tool.loadtest.loadtest_adapters import (
 )
 from controlplane_tool.scenario.catalog import ScenarioDefinition
 from controlplane_tool.scenario.components.executor import ScenarioPlanStep
+from controlplane_tool.scenario.scenarios._workflow_assembly import (
+    _Setup,
+    build_command_tasks,
+    build_setup,
+)
 from controlplane_tool.scenario.two_vm_loadtest_config import (
     LOADTEST_PROMETHEUS_QUERIES,
-    LOADTEST_STATIC_TASK_IDS,
     two_vm_control_plane_url,
     two_vm_load_stages,
     two_vm_prometheus_url,
@@ -42,6 +47,46 @@ if TYPE_CHECKING:
     from controlplane_tool.e2e.e2e_runner import E2eRunner
 
 
+# Components run on the stack VM before loadgen starts.
+# vm.ensure_running is handled separately (EnsureVmRunning task outside the Workflow).
+_TWO_VM_STACK_PRELUDE_COMPONENTS: tuple[str, ...] = (
+    "vm.provision_base",
+    "repo.sync_to_vm",
+    "registry.ensure_container",
+    "images.build_core",
+    "images.build_selected_functions",
+    "k3s.install",
+    "k3s.configure_registry",
+    "namespace.install",
+    "helm.deploy_control_plane",
+    "helm.deploy_function_runtime",
+)
+
+# Static task IDs used for TUI dry-run planning and test assertions.
+# Component IDs for provisioning phases (expand to multiple operations at runtime).
+_TWO_VM_STATIC_TASK_IDS: tuple[str, ...] = (
+    "vm.stack.ensure_running",
+    "vm.provision_base",
+    "repo.sync_to_vm",
+    "registry.ensure_container",
+    "images.build_core",
+    "images.build_selected_functions",
+    "k3s.install",
+    "k3s.configure_registry",
+    "namespace.install",
+    "helm.deploy_control_plane",
+    "helm.deploy_function_runtime",
+    "vm.loadgen.ensure_running",
+    "loadgen.install_k6",
+    "loadgen.run_k6",
+    "loadgen.fetch_results",
+    "metrics.prometheus_snapshot",
+    "loadtest.write_report",
+    "vm.loadgen.destroy",
+    "vm.stack.destroy",
+)
+
+
 @dataclass
 class TwoVmLoadtestPlan:
     scenario: ScenarioDefinition
@@ -51,60 +96,84 @@ class TwoVmLoadtestPlan:
 
     @property
     def task_ids(self) -> list[str]:
-        return list(LOADTEST_STATIC_TASK_IDS)
+        return list(_TWO_VM_STATIC_TASK_IDS)
 
     @property
     def phase_titles(self) -> list[str]:
-        pre, wf = self._skeleton()
-        return [t.title for t in pre] + wf.phase_titles
-
-    def _skeleton(self) -> "tuple[list[EnsureVmRunning], Workflow]":
-        """Task objects with None adapters — only task_id and title are valid here."""
-        r = self.request
-        sc = VmConfig(name=r.vm.name or "", cpus=r.vm.cpus, memory=r.vm.memory, disk=r.vm.disk)
-        lc = VmConfig(name=r.loadgen_vm.name or "", cpus=r.loadgen_vm.cpus, memory=r.loadgen_vm.memory, disk=r.loadgen_vm.disk)
-        pre = [
-            EnsureVmRunning(task_id="vm.stack.ensure_running", title="Ensure stack VM running", lifecycle=None, config=sc),  # type: ignore[arg-type]
-            EnsureVmRunning(task_id="vm.loadgen.ensure_running", title="Ensure loadgen VM running", lifecycle=None, config=lc),  # type: ignore[arg-type]
-        ]
-        wf = Workflow(
-            tasks=[
-                InstallK6(task_id="loadgen.install_k6", title="Install k6 on loadgen VM", runner=None, remote_dir=None),  # type: ignore[arg-type]
-                RunK6(task_id="loadgen.run_k6", title="Run k6 loadtest", runner=None, config=None, remote_dir=None),  # type: ignore[arg-type]
-                FetchVmResults(task_id="loadgen.fetch_results", title="Fetch k6 results from loadgen VM", fetcher=None, remote_source=None, local_dest=None),  # type: ignore[arg-type]
-                CapturePrometheusSnapshot(task_id="metrics.prometheus_snapshot", title="Capture Prometheus snapshots", client=None, queries=None, window=None, output_dir=None),  # type: ignore[arg-type]
-                WriteK6Report(task_id="loadtest.write_report", title="Write loadtest report", data_dir=None, output_dir=None),  # type: ignore[arg-type]
-            ],
-            cleanup_tasks=[
-                DestroyVm(task_id="vm.loadgen.destroy", title="Destroy loadgen VM", lifecycle=None, info=None),  # type: ignore[arg-type]
-            ],
+        setup = self._build_setup()
+        stack_tasks = self._build_stack_prelude_tasks(setup, resolve_host=False)
+        return (
+            ["Ensure stack VM running"]
+            + [t.title for t in stack_tasks]
+            + [
+                "Ensure loadgen VM running",
+                "Install k6 on loadgen VM",
+                "Run k6 loadtest",
+                "Fetch k6 results from loadgen VM",
+                "Capture Prometheus snapshots",
+                "Write loadtest report",
+                "Destroy loadgen VM",
+                "Destroy stack VM",
+            ]
         )
-        return pre, wf
+
+    def _build_setup(self) -> _Setup:
+        return build_setup(self.runner, self.request)
+
+    def _build_stack_prelude_tasks(self, setup: _Setup, *, resolve_host: bool = True) -> list:
+        recipe = ScenarioRecipe(
+            name="two-vm-loadtest-stack",
+            component_ids=_TWO_VM_STACK_PRELUDE_COMPONENTS,
+            requires_managed_vm=True,
+        )
+        return build_command_tasks(
+            self.runner, self.request, setup, recipe, resolve_host=resolve_host
+        )
 
     def run(self, event_listener=None) -> None:
         from controlplane_tool.e2e.two_vm_loadtest_runner import TwoVmLoadtestRunner
 
+        setup = self._build_setup()
         request = self.request
-        vm_runner_impl = TwoVmLoadtestRunner(repo_root=self.runner.paths.workspace_root)
-        lifecycle = MultipassVmAdapter(vm_runner_impl.vm)
 
-        [s_ensure_stack, s_ensure_loadgen], s_wf = self._skeleton()
-        [s_install_k6, s_run_k6, s_fetch, s_prom, s_report] = s_wf.tasks
-        [s_destroy] = s_wf.cleanup_tasks
-
-        stack_config = VmConfig(name=request.vm.name, cpus=request.vm.cpus, memory=request.vm.memory, disk=request.vm.disk)
-        loadgen_config = VmConfig(name=request.loadgen_vm.name, cpus=request.loadgen_vm.cpus, memory=request.loadgen_vm.memory, disk=request.loadgen_vm.disk)
-
-        ensure_stack = EnsureVmRunning(task_id=s_ensure_stack.task_id, title=s_ensure_stack.title, lifecycle=lifecycle, config=stack_config)
-        ensure_loadgen = EnsureVmRunning(task_id=s_ensure_loadgen.task_id, title=s_ensure_loadgen.title, lifecycle=lifecycle, config=loadgen_config)
-
+        # ── 1. Ensure stack VM running ──────────────────────────────────────────
+        ensure_stack = EnsureVmRunning(
+            task_id="vm.stack.ensure_running",
+            title="Ensure stack VM running",
+            lifecycle=setup.lifecycle,
+            config=setup.vm_config,
+        )
         with workflow_step(task_id=ensure_stack.task_id, title=ensure_stack.title):
             stack_info = ensure_stack.run()
+
+        # ── 2. Stack provisioning (provision, sync, build, k3s, deploy) ────────
+        stack_tasks = self._build_stack_prelude_tasks(setup)
+        Workflow(tasks=stack_tasks).run()
+
+        # ── 3. Ensure loadgen VM running ────────────────────────────────────────
+        lifecycle = setup.lifecycle
+        loadgen_config = VmConfig(
+            name=request.loadgen_vm.name or "",
+            cpus=request.loadgen_vm.cpus,
+            memory=request.loadgen_vm.memory,
+            disk=request.loadgen_vm.disk,
+        )
+        ensure_loadgen = EnsureVmRunning(
+            task_id="vm.loadgen.ensure_running",
+            title="Ensure loadgen VM running",
+            lifecycle=lifecycle,
+            config=loadgen_config,
+        )
         with workflow_step(task_id=ensure_loadgen.task_id, title=ensure_loadgen.title):
             loadgen_info = ensure_loadgen.run()
 
+        # ── 4. Loadgen workflow ─────────────────────────────────────────────────
+        vm_runner_impl = TwoVmLoadtestRunner(repo_root=self.runner.paths.workspace_root)
         remote_home = loadgen_info.home
-        remote_paths = two_vm_remote_paths(remote_home, payload_name=request.k6_payload.name if request.k6_payload is not None else None)
+        remote_paths = two_vm_remote_paths(
+            remote_home,
+            payload_name=request.k6_payload.name if request.k6_payload is not None else None,
+        )
         run_dir = vm_runner_impl._create_run_dir()  # noqa: SLF001
         control_plane_url = two_vm_control_plane_url(request.vm, host=stack_info.host)
 
@@ -127,27 +196,66 @@ class TwoVmLoadtestPlan:
         fetcher = VmFileFetcher(vm=vm_runner_impl.vm, request=request.loadgen_vm)
         prom_client = HttpPrometheusClient(url=two_vm_prometheus_url(request.vm, host=stack_info.host))
 
-        k6_task = RunK6(task_id=s_run_k6.task_id, title=s_run_k6.title, runner=loadgen_runner, config=k6_config, remote_dir=remote_home)
+        k6_task = RunK6(
+            task_id="loadgen.run_k6",
+            title="Run k6 loadtest",
+            runner=loadgen_runner,
+            config=k6_config,
+            remote_dir=remote_home,
+        )
 
-        workflow = Workflow(
+        cleanup: list = []
+        if getattr(request, "cleanup_vm", True):
+            cleanup = [
+                DestroyVm(
+                    task_id="vm.loadgen.destroy",
+                    title="Destroy loadgen VM",
+                    lifecycle=lifecycle,
+                    info=loadgen_info,
+                ),
+                DestroyVm(
+                    task_id="vm.stack.destroy",
+                    title="Destroy stack VM",
+                    lifecycle=setup.lifecycle,
+                    info=stack_info,
+                ),
+            ]
+
+        Workflow(
             tasks=[
-                InstallK6(task_id=s_install_k6.task_id, title=s_install_k6.title, runner=loadgen_runner, remote_dir=remote_home),
+                InstallK6(
+                    task_id="loadgen.install_k6",
+                    title="Install k6 on loadgen VM",
+                    runner=loadgen_runner,
+                    remote_dir=remote_home,
+                ),
                 k6_task,
-                FetchVmResults(task_id=s_fetch.task_id, title=s_fetch.title, fetcher=fetcher, remote_source=remote_paths.summary_path, local_dest=run_dir),
+                FetchVmResults(
+                    task_id="loadgen.fetch_results",
+                    title="Fetch k6 results from loadgen VM",
+                    fetcher=fetcher,
+                    remote_source=remote_paths.summary_path,
+                    local_dest=run_dir,
+                ),
                 CapturePrometheusSnapshot(
-                    task_id=s_prom.task_id, title=s_prom.title,
+                    task_id="metrics.prometheus_snapshot",
+                    title="Capture Prometheus snapshots",
                     client=prom_client,
                     queries=LOADTEST_PROMETHEUS_QUERIES,
-                    window=lambda: TimeWindow(start=k6_task.result.started_at, end=k6_task.result.ended_at),
+                    window=lambda: TimeWindow(
+                        start=k6_task.result.started_at, end=k6_task.result.ended_at
+                    ),
                     output_dir=run_dir,
                 ),
-                WriteK6Report(task_id=s_report.task_id, title=s_report.title, data_dir=run_dir, output_dir=run_dir),
+                WriteK6Report(
+                    task_id="loadtest.write_report",
+                    title="Write loadtest report",
+                    data_dir=run_dir,
+                    output_dir=run_dir,
+                ),
             ],
-            cleanup_tasks=[
-                DestroyVm(task_id=s_destroy.task_id, title=s_destroy.title, lifecycle=lifecycle, info=loadgen_info),
-            ],
-        )
-        workflow.run()
+            cleanup_tasks=cleanup,
+        ).run()
 
 
 def build_two_vm_loadtest_plan(

--- a/tools/controlplane/tests/test_two_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_plan.py
@@ -8,7 +8,7 @@ from controlplane_tool.scenario.scenarios.two_vm_loadtest import TwoVmLoadtestPl
 
 
 def test_two_vm_loadtest_plan_has_expected_task_ids() -> None:
-    """task_ids must include all steps for TUI dry-run planning."""
+    """task_ids must include all phases: stack provisioning + loadgen + cleanup."""
     runner = MagicMock()
     runner.paths.workspace_root = Path("/repo")
     request = MagicMock()
@@ -17,11 +17,24 @@ def test_two_vm_loadtest_plan_has_expected_task_ids() -> None:
     plan = TwoVmLoadtestPlan(scenario=scenario, request=request, steps=[], runner=runner)
 
     ids = plan.task_ids
+    # Stack VM lifecycle
     assert "vm.stack.ensure_running" in ids
+    # Stack provisioning phases
+    assert "vm.provision_base" in ids
+    assert "repo.sync_to_vm" in ids
+    assert "registry.ensure_container" in ids
+    assert "images.build_core" in ids
+    assert "images.build_selected_functions" in ids
+    assert "k3s.install" in ids
+    assert "helm.deploy_control_plane" in ids
+    assert "helm.deploy_function_runtime" in ids
+    # Loadgen phases
     assert "vm.loadgen.ensure_running" in ids
     assert "loadgen.install_k6" in ids
     assert "loadgen.run_k6" in ids
     assert "loadgen.fetch_results" in ids
     assert "metrics.prometheus_snapshot" in ids
     assert "loadtest.write_report" in ids
+    # Cleanup
     assert "vm.loadgen.destroy" in ids
+    assert "vm.stack.destroy" in ids

--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible_assets/playbooks/install-k6.yml
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible_assets/playbooks/install-k6.yml
@@ -31,27 +31,6 @@
         k6_arch: "{{ k6_arch_map.get(ansible_architecture, '') }}"
 
   tasks:
-    - name: Fail when k6 is requested on an unsupported architecture
-      ansible.builtin.fail:
-        msg: "Unsupported architecture for k6: {{ ansible_architecture }}"
-      when: k6_arch | length == 0
-
-    - name: Resolve latest k6 release from GitHub
-      ansible.builtin.uri:
-        url: "{{ k6_release_api_url }}"
-        headers:
-          Accept: application/vnd.github+json
-        return_content: true
-        status_code: 200
-      delegate_to: localhost
-      become: false
-      run_once: true
-      register: k6_release
-
-    - name: Set target k6 version
-      ansible.builtin.set_fact:
-        k6_target_version: "{{ k6_release.json.tag_name }}"
-
     - name: Check installed k6 version
       ansible.builtin.command: k6 version
       register: k6_installed
@@ -67,34 +46,84 @@
             else ""
           }}
 
-    - name: Ensure k6 archive extraction directory exists
-      ansible.builtin.file:
-        path: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}"
-        state: directory
-        mode: "0755"
-      when: k6_installed_version != k6_target_version
+    # ── Ubuntu: install via Grafana apt repository ───────────────────────────
+    - name: Install k6 via apt (Ubuntu)
+      when: ansible_distribution == 'Ubuntu' and k6_installed_version == ""
+      block:
+        - name: Download Grafana GPG key for k6
+          ansible.builtin.get_url:
+            url: https://dl.k6.io/key.gpg
+            dest: /tmp/k6-keyring.gpg
+            mode: "0644"
 
-    - name: Download k6 release archive
-      ansible.builtin.get_url:
-        url: "https://github.com/grafana/k6/releases/download/{{ k6_target_version }}/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
-        dest: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
-        mode: "0644"
-      when: k6_installed_version != k6_target_version
+        - name: Dearmor Grafana GPG key
+          ansible.builtin.command:
+            cmd: gpg --yes --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg /tmp/k6-keyring.gpg
+          args:
+            creates: /usr/share/keyrings/k6-archive-keyring.gpg
 
-    - name: Extract k6 release archive
-      ansible.builtin.unarchive:
-        src: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
-        dest: "/tmp"
-        remote_src: true
-        creates: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}/k6"
-      when: k6_installed_version != k6_target_version
+        - name: Add k6 apt repository
+          ansible.builtin.copy:
+            dest: /etc/apt/sources.list.d/k6.list
+            content: "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main\n"
+            mode: "0644"
 
-    - name: Install k6 binary
-      ansible.builtin.copy:
-        src: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}/k6"
-        dest: /usr/local/bin/k6
-        remote_src: true
-        owner: root
-        group: root
-        mode: "0755"
-      when: k6_installed_version != k6_target_version
+        - name: Install k6 via apt
+          ansible.builtin.apt:
+            name: k6
+            state: present
+            update_cache: true
+            lock_timeout: 120
+
+    # ── Non-Ubuntu: install via GitHub binary download ───────────────────────
+    - name: Install k6 via binary download (non-Ubuntu)
+      when: ansible_distribution != 'Ubuntu' and k6_installed_version == ""
+      block:
+        - name: Fail when k6 is requested on an unsupported architecture
+          ansible.builtin.fail:
+            msg: "Unsupported architecture for k6: {{ ansible_architecture }}"
+          when: k6_arch | length == 0
+
+        - name: Resolve latest k6 release from GitHub
+          ansible.builtin.uri:
+            url: "{{ k6_release_api_url }}"
+            headers:
+              Accept: application/vnd.github+json
+            return_content: true
+            status_code: 200
+          delegate_to: localhost
+          become: false
+          run_once: true
+          register: k6_release
+
+        - name: Set target k6 version
+          ansible.builtin.set_fact:
+            k6_target_version: "{{ k6_release.json.tag_name }}"
+
+        - name: Ensure k6 archive extraction directory exists
+          ansible.builtin.file:
+            path: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}"
+            state: directory
+            mode: "0755"
+
+        - name: Download k6 release archive
+          ansible.builtin.get_url:
+            url: "https://github.com/grafana/k6/releases/download/{{ k6_target_version }}/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
+            dest: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
+            mode: "0644"
+
+        - name: Extract k6 release archive
+          ansible.builtin.unarchive:
+            src: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}.tar.gz"
+            dest: "/tmp"
+            remote_src: true
+            creates: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}/k6"
+
+        - name: Install k6 binary
+          ansible.builtin.copy:
+            src: "/tmp/k6-{{ k6_target_version }}-linux-{{ k6_arch }}/k6"
+            dest: /usr/local/bin/k6
+            remote_src: true
+            owner: root
+            group: root
+            mode: "0755"

--- a/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
+++ b/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
@@ -15,24 +15,22 @@ if TYPE_CHECKING:
     from workflow_tasks.tasks.executors import VmCommandRunner
 
 
+# Install k6 by downloading the binary from GitHub releases.
+# Avoids apt-repo setup entirely: curl|gpg pipelines fail silently when the key URL
+# changes or network is flaky, leaving apt unaware of the k6 package.
 _K6_INSTALL_CMD: tuple[str, ...] = (
     "bash",
     "-lc",
-    (
-        "which k6 || ("
-        "if command -v cloud-init >/dev/null 2>&1; then sudo cloud-init status --wait || true; fi"
-        " && for i in $(seq 1 60); do "
-        "if sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; "
-        "then sleep 5; else break; fi; done"
-        " && if sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; "
-        "then echo 'apt locks still held after waiting' >&2; exit 1; fi"
-        " && "
-        "curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg"
-        " && echo 'deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main'"
-        " | sudo tee /etc/apt/sources.list.d/k6.list"
-        " && sudo apt-get -o DPkg::Lock::Timeout=120 update -qq"
-        " && sudo apt-get -o DPkg::Lock::Timeout=120 install -y k6)"
-    ),
+    "which k6 2>/dev/null && exit 0; "
+    "set -euo pipefail; "
+    "K6_VER=$(curl -fsSL https://api.github.com/repos/grafana/k6/releases/latest"
+    " | python3 -c \"import json,sys; print(json.load(sys.stdin)['tag_name'])\"); "
+    "ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); "
+    "TMP=$(mktemp -d); "
+    "curl -fsSL \"https://github.com/grafana/k6/releases/download/${K6_VER}/k6-${K6_VER}-linux-${ARCH}.tar.gz\""
+    " | tar -xz -C \"$TMP\"; "
+    "sudo install -m 0755 \"$TMP/k6-${K6_VER}-linux-${ARCH}/k6\" /usr/local/bin/k6; "
+    "rm -rf \"$TMP\"",
 )
 
 


### PR DESCRIPTION
## Summary

- **two-vm-loadtest**: aggiunto pipeline completo di provisioning stack VM (provision base, sync repo, build immagini, k3s, deploy Helm) prima della fase loadgen; prima lo scenario assumeva una VM già provvisionata
- **install-k6.yml**: usa apt su Ubuntu (Grafana repo via `get_url` + `gpg --dearmor`), binary download da GitHub releases su non-Ubuntu
- **`_K6_INSTALL_CMD`** (bash fallback): sostituita la pipeline `curl|gpg` con download diretto del binario; il pipe falliva silenziosamente causando `E: Unable to locate package k6`
- **test_two_vm_loadtest_plan**: assert aggiornati per verificare la presenza dei task ID di provisioning

## Test plan

- [ ] `uv run --project tools/controlplane pytest tools/controlplane/tests/` — 1125 passed
- [ ] Eseguire scenario `two-vm-loadtest` con VM Multipass per verificare il pipeline completo end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)