### PR TITLE
Unify k6 install on ansible (RunPlaybook + install_k6_task)

### DIFF
--- a/docs/superpowers/plans/2026-06-04-ansible-task-unification.md
+++ b/docs/superpowers/plans/2026-06-04-ansible-task-unification.md
@@ -2,13 +2,13 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Provide one reusable, TUI-aware ansible task (`RunPlaybook`) plus a shared `install_k6_task` factory, and migrate the `two-vm-loadtest` loadgen k6 install from the hand-built bash `InstallK6` to ansible — additively (bash kept, deprecated).
+**Goal:** Provide one reusable, TUI-aware ansible task (`RunPlaybook`) plus a shared `install_k6_task` factory, and migrate the loadgen k6 install of all three loadtest scenarios (`two-vm`, `azure`, `proxmox`) from the hand-built bash `InstallK6` to ansible — additively (bash kept, deprecated).
 
 **Architecture:** Reuse the existing `AnsibleAdapter` (`workflow_tasks/infra/ansible.py`), which already builds and runs `ansible-playbook` on the host shell (with live TUI log streaming via `SubprocessShell`). Add a public generic `run_playbook()` method (DRY-refactoring the typed methods onto it), a thin `RunPlaybook` Task wrapper, and a connectivity-parametric `install_k6_task` factory. The factory turns per-lifecycle SSH connectivity into constructor arguments `(host, user, private_key, port)` — `port` flows through ansible's `-e ansible_port=...`.
 
 **Tech Stack:** Python 3.12, `dataclasses`, `pytest`, `uv`, ansible (`ansible-playbook`), `workflow_tasks` library, `controlplane_tool`.
 
-**Scope:** Phase 1 (reusable bricks + tests) and Phase 2a (two-vm migration). `azure-vm-loadtest` and `proxmox-vm-loadtest` migrations are **deferred** to a follow-up plan — they require first exposing each orchestrator's loadgen SSH endpoint (proxmox: published host + mapped SSH port + key; azure: public host + key). See "Deferred" at the end.
+**Scope:** Phase 1 (reusable bricks + tests) and Phase 2 — migrating the loadgen k6 install of **all three** loadtest scenarios (`two-vm`, `azure`, `proxmox`) to ansible. The orchestrators already expose the needed loadgen SSH endpoint: proxmox via public `ssh_endpoint()` + `ssh_private_key_path()`; azure via `connection_host()` + a new `ssh_private_key_path()` (added in Task 5). Out of scope (Phase 3, documented in the spec): recipe-fragment composition to collapse near-identical scenarios, and helm/namespace/cleanup → ansible.
 
 **Note vs spec:** the spec proposed a new `workflow_tasks/infra/ansible/` directory. Since `workflow_tasks/infra/ansible.py` already exists and houses `AnsibleAdapter`, `RunPlaybook` and `install_k6_task` are co-located there (cohesion, no import breakage). Same intent, pragmatic placement.
 
@@ -21,6 +21,9 @@
 - `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py` — new tests for `run_playbook`, `RunPlaybook`, `install_k6_task`.
 - `tools/workflow-tasks/tests/test_public_api.py` — assert new exports.
 - `tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py` — replace bash `InstallK6` instantiation with `install_k6_task(...)`.
+- `tools/workflow-tasks/src/workflow_tasks/vm/azure.py` — add public `ssh_private_key_path()` (mirrors proxmox).
+- `tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py` — replace bash `InstallK6` in `run()` with `install_k6_task(...)`.
+- `tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py` — replace bash `InstallK6` in `_install_k6` with `install_k6_task(...)`.
 
 ---
 
@@ -501,7 +504,213 @@ git commit -m "refactor(two-vm-loadtest): install k6 via ansible RunPlaybook"
 
 ---
 
-## Task 5: Full suites + deprecation note
+## Task 5: Add public `ssh_private_key_path` to `AzureVmProvider`
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/vm/azure.py`
+- Test: `tools/workflow-tasks/tests/test_vm_lifecycle_adapters.py` (or the azure provider test module)
+
+Context: `AzureVmProvider` has a private `_ssh_key(request)` and a public `connection_host(request)`. Proxmox already exposes a public `ssh_private_key_path()`. Add the symmetric public method to azure so scenario code resolves the loadgen key through a clean boundary.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the azure provider test module (e.g. `tools/workflow-tasks/tests/test_vm_lifecycle_adapters.py`):
+
+```python
+def test_azure_provider_exposes_ssh_private_key_path(tmp_path) -> None:
+    from pathlib import Path
+
+    from workflow_tasks.vm.azure import AzureVmProvider
+    from workflow_tasks.vm.models import VmRequest
+
+    key = tmp_path / "id_ed25519"
+    key.write_text("x")
+    provider = AzureVmProvider(repo_root=Path("/repo"))
+    request = VmRequest(lifecycle="azure", name="loadgen", user="azureuser", azure_ssh_key_path=str(key))
+
+    assert provider.ssh_private_key_path(request) == key
+```
+
+> If `VmRequest` lacks `azure_ssh_key_path`, check the field name in `workflow_tasks/vm/models.py` and use the actual one (the azure provider reads `request.azure_ssh_key_path`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/test_vm_lifecycle_adapters.py -v -k ssh_private_key_path`
+Expected: FAIL with `AttributeError: 'AzureVmProvider' object has no attribute 'ssh_private_key_path'`.
+
+- [ ] **Step 3: Add the public method**
+
+In `azure.py`, add right after `_ssh_key`:
+
+```python
+    def ssh_private_key_path(self, request: VmRequest) -> Path | None:
+        return self._ssh_key(request)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/test_vm_lifecycle_adapters.py -v -k ssh_private_key_path`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/vm/azure.py tools/workflow-tasks/tests/test_vm_lifecycle_adapters.py
+git commit -m "feat(azure): expose public ssh_private_key_path"
+```
+
+---
+
+## Task 6: Migrate `azure-vm-loadtest` loadgen install to ansible
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py:148-151`
+- Test: `tools/controlplane/tests/test_azure_vm_loadtest_runner.py`
+
+Context: `azure_vm_loadtest.py` `run()` (lines ~84-166) builds `azure_orch = AzureVmOrchestrator(...)`, ensures both VMs, then a `Workflow(tasks=[InstallK6(task_id=s_install_k6.task_id, ..., runner=loadgen_runner, remote_dir=remote_home), ...])`. The `_skeleton()` method keeps its `InstallK6(..., runner=None, ...)` placeholder purely for `task_id`/`title` — leave it; only `run()`'s real instantiation changes. Azure VMs have public IPs reachable by host ansible; `connection_host()` returns the public IP, `ssh_private_key_path()` (Task 5) the key.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tools/controlplane/tests/test_azure_vm_loadtest_runner.py`:
+
+```python
+def test_azure_loadgen_install_uses_runplaybook_not_bash() -> None:
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import azure_vm_loadtest
+
+    source = inspect.getsource(azure_vm_loadtest.AzureVmLoadtestPlan.run)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_azure_vm_loadtest_runner.py::test_azure_loadgen_install_uses_runplaybook_not_bash -v`
+Expected: FAIL — `run()` still contains `InstallK6(`.
+
+- [ ] **Step 3: Update imports in `azure_vm_loadtest.py`**
+
+In the `from workflow_tasks import (...)` block (keep `InstallK6` — still used by `_skeleton`), add `install_k6_task,`.
+
+- [ ] **Step 4: Replace the bash install task in `run()`**
+
+Replace the `InstallK6(task_id=s_install_k6.task_id, title=s_install_k6.title, runner=loadgen_runner, remote_dir=remote_home)` entry inside `Workflow(tasks=[...])` (line ~150) with:
+
+```python
+                install_k6_task(
+                    task_id=s_install_k6.task_id,
+                    title=s_install_k6.title,
+                    repo_root=self.runner.paths.workspace_root,
+                    shell=self.runner.shell,
+                    host=azure_orch.connection_host(request.loadgen_vm),
+                    user=request.loadgen_vm.user,
+                    private_key=azure_orch.ssh_private_key_path(request.loadgen_vm),
+                ),
+```
+
+- [ ] **Step 5: Run the guard test + the azure runner suite**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_azure_vm_loadtest_runner.py -v`
+Expected: PASS (guard test passes; the existing runner tests use a mock orchestrator for `RunK6` and are unaffected by the install change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py tools/controlplane/tests/test_azure_vm_loadtest_runner.py
+git commit -m "refactor(azure-vm-loadtest): install k6 via ansible RunPlaybook"
+```
+
+---
+
+## Task 7: Migrate `proxmox-vm-loadtest` loadgen install to ansible
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py:730-736`
+- Test: `tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py:217-326`
+
+Context: in `_tail_tasks`, the `_install_k6` callable currently runs the bash `InstallK6(...)` via `OrchestratorVmRunner`. Proxmox exposes public `ssh_endpoint(request) -> (host, port)` (publishes the SSH NAT rule if missing) and `ssh_private_key_path(request)`. The loadgen VM is created with the SSH public key via cloud-init, so it is reachable by host ansible. `self.runner` (E2eRunner) and `loadgen_request`/`proxmox_orch` are in scope inside `_tail_tasks`.
+
+- [ ] **Step 1: Update the existing tail-events test (it monkeypatches `InstallK6`)**
+
+In `tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py`, in `test_proxmox_vm_loadtest_tail_events_start_after_prelude`:
+
+(a) Add the two new methods to `FakeProxmoxVmOrchestrator` (after `publish_port`):
+
+```python
+        def ssh_endpoint(self, request):
+            return "127.0.0.1", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+```
+
+(b) Replace the line `monkeypatch.setattr(proxmox_plan, "InstallK6", FakeTask)` with:
+
+```python
+    monkeypatch.setattr(proxmox_plan, "install_k6_task", FakeTask)
+```
+
+(`FakeTask.__init__` accepts `task_id, title, **kwargs`, so it absorbs the factory's keyword args.)
+
+- [ ] **Step 2: Add the guard test**
+
+Add to the same test file:
+
+```python
+def test_proxmox_loadgen_install_uses_runplaybook_not_bash() -> None:
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import proxmox_vm_loadtest
+
+    source = inspect.getsource(proxmox_vm_loadtest.ProxmoxVmLoadtestPlan._tail_tasks)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py -v -k "tail_events or runplaybook_not_bash"`
+Expected: FAIL — `_tail_tasks` still contains `InstallK6(`; the tail-events test fails because `install_k6_task` is not yet a module name to patch.
+
+- [ ] **Step 4: Update imports in `proxmox_vm_loadtest.py`**
+
+In the `from workflow_tasks import (...)` block (keep `InstallK6` — still used by `_skeleton` at line ~167), add `install_k6_task,`.
+
+- [ ] **Step 5: Replace the bash install in `_install_k6`**
+
+Replace the `_install_k6` body (lines ~730-736) with:
+
+```python
+        def _install_k6() -> None:
+            host, port = proxmox_orch.ssh_endpoint(loadgen_request)
+            install_k6_task(
+                task_id=s_install_k6.task_id,
+                title=s_install_k6.title,
+                repo_root=self.runner.paths.workspace_root,
+                shell=self.runner.shell,
+                host=host,
+                user=loadgen_request.user,
+                private_key=proxmox_orch.ssh_private_key_path(loadgen_request),
+                port=port,
+            ).run()
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py -v`
+Expected: PASS (guard test, tail-events test, task_id/ordering tests — `loadgen.install_k6` still present).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+git commit -m "refactor(proxmox-vm-loadtest): install k6 via ansible RunPlaybook"
+```
+
+---
+
+## Task 8: Full suites + deprecation note
 
 **Files:**
 - Modify: `tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py` (docstring only)
@@ -542,19 +751,17 @@ git commit -m "docs(loadtest): mark bash InstallK6 deprecated in favor of ansibl
 
 ---
 
-## Deferred (follow-up plan): azure & proxmox loadgen migration
+## Out of scope (Phase 3, documented in the spec)
 
-Not in this plan because accurate code requires first **exposing each orchestrator's loadgen SSH endpoint** for host-side ansible:
-
-- **proxmox** — ansible from host must target the **proxmox host at the published SSH port** (not the guest IP). Prerequisite: resolve `(host, port, key)` for the loadgen VM via the proxmox orchestrator (`_ssh_key(loadgen_request)`, `_published_rule(loadgen_request, "SSH").host_port`) and ensure the loadgen SSH port is published. Then call `install_k6_task(..., host=<proxmox_host>, port=<published_port>, private_key=<key>)` in `proxmox_vm_loadtest.py`'s `_install_k6`.
-- **azure** — confirm `AzureVmOrchestrator` exposes the loadgen VM's public host (`loadgen_info.host`) **and** SSH key path/user. Then call `install_k6_task(..., host=loadgen_info.host, user=..., private_key=<azure key>)` in `azure_vm_loadtest.py`'s `run()`.
-
-Both then update their argv-oracle tests (`test_proxmox_vm_loadtest_plan.py`, `test_azure_vm_loadtest_runner.py`) to expect `ansible-playbook ... install-k6.yml`. The `install_k6_task` factory built here is the shared brick they will reuse.
+- **Recipe-fragment composition** (spec §4.4 Axis A): replace the flat `ScenarioRecipe` tuples with shared fragments (`PROVISION_PRELUDE`, `LOADGEN_SEQUENCE`) so near-identical scenarios compose instead of duplicate. With `install_k6_task` proving connectivity-as-parameters (Axis B), this collapses two-vm/azure/proxmox toward one shared definition.
+- **helm / namespace / cleanup → ansible** (`helm` module) — large, low-value-for-now conversion.
+- **Removing the deprecated bash `InstallK6`** classes once nothing references them.
 
 ---
 
 ## Self-Review
 
-- **Spec coverage:** RunPlaybook (§4.1) → Tasks 2; generic via AnsibleAdapter.run_playbook → Task 1; TUI integration (§4.2) → satisfied by SubprocessShell live-log streaming (baseline; structured sub-steps noted as future); connectivity adapter (§4.4 Axis B) → `install_k6_task` factory (Task 3); two-vm migration (§4.3) → Task 4; additive/bash kept (§3 goals) → Task 5; azure/proxmox + recipe-fragment composition (§4.4 Axis A, Phase 3) → explicitly Deferred, matching the spec's phasing. Mapping (§2) lives in the committed spec.
-- **Placeholder scan:** no TBD/TODO; all code blocks concrete. The one conditional note (`ScriptedShell` signature) gives the behavioral contract to satisfy.
-- **Type consistency:** `RunPlaybook(task_id, title, adapter, playbook, request, extra_vars)` used identically in Tasks 2/3/4; `install_k6_task(*, task_id, title, repo_root, shell, host, user, private_key=None, port=None)` keyword-only signature used identically in Task 3 tests and Task 4 call site; `AnsibleAdapter.run_playbook(playbook_name, request, *, extra_vars, dry_run)` matches `_build_command`'s existing signature.
+- **Spec coverage:** generic ansible exec via `AnsibleAdapter.run_playbook` → Task 1; `RunPlaybook` (§4.1) → Task 2; TUI integration (§4.2) → SubprocessShell live-log streaming (baseline; structured per-ansible-task sub-steps noted as future); connectivity adapter (§4.4 Axis B) → `install_k6_task` factory (Task 3); migration of all three loadtest scenarios (§4.3) → Tasks 4 (two-vm), 6 (azure), 7 (proxmox), with azure key boundary in Task 5; additive/bash kept + deprecation note (§3 goals) → Task 8; recipe-fragment composition + helm (§4.4 Axis A, Phase 3) → explicitly out of scope. Mapping (§2) lives in the committed spec.
+- **Placeholder scan:** no TBD/TODO; all code blocks concrete. Conditional notes (`VmRequest.azure_ssh_key_path` field name) give the contract to satisfy.
+- **Type consistency:** `RunPlaybook(task_id, title, adapter, playbook, request, extra_vars)` used identically across Tasks 2/3/4; `install_k6_task(*, task_id, title, repo_root, shell, host, user, private_key=None, port=None)` keyword-only signature identical in Task 3 tests and the Task 4/6/7 call sites; `AnsibleAdapter.run_playbook(playbook_name, request, *, extra_vars, dry_run)` matches `_build_command`'s signature; proxmox `ssh_endpoint(request) -> (host, port)` and `ssh_private_key_path(request)` are existing public methods; azure `connection_host(request)` existing + `ssh_private_key_path(request)` added in Task 5.
+- **Cross-test integrity:** Task 7 updates the existing `test_proxmox_vm_loadtest_tail_events_start_after_prelude` (which monkeypatches the module-level install symbol and uses a fake orchestrator) to patch `install_k6_task` and to add `ssh_endpoint`/`ssh_private_key_path` to `FakeProxmoxVmOrchestrator` — otherwise the migrated `_install_k6` would call methods the fake lacks.

--- a/docs/superpowers/plans/2026-06-04-ansible-task-unification.md
+++ b/docs/superpowers/plans/2026-06-04-ansible-task-unification.md
@@ -1,0 +1,560 @@
+# Ansible Task Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide one reusable, TUI-aware ansible task (`RunPlaybook`) plus a shared `install_k6_task` factory, and migrate the `two-vm-loadtest` loadgen k6 install from the hand-built bash `InstallK6` to ansible — additively (bash kept, deprecated).
+
+**Architecture:** Reuse the existing `AnsibleAdapter` (`workflow_tasks/infra/ansible.py`), which already builds and runs `ansible-playbook` on the host shell (with live TUI log streaming via `SubprocessShell`). Add a public generic `run_playbook()` method (DRY-refactoring the typed methods onto it), a thin `RunPlaybook` Task wrapper, and a connectivity-parametric `install_k6_task` factory. The factory turns per-lifecycle SSH connectivity into constructor arguments `(host, user, private_key, port)` — `port` flows through ansible's `-e ansible_port=...`.
+
+**Tech Stack:** Python 3.12, `dataclasses`, `pytest`, `uv`, ansible (`ansible-playbook`), `workflow_tasks` library, `controlplane_tool`.
+
+**Scope:** Phase 1 (reusable bricks + tests) and Phase 2a (two-vm migration). `azure-vm-loadtest` and `proxmox-vm-loadtest` migrations are **deferred** to a follow-up plan — they require first exposing each orchestrator's loadgen SSH endpoint (proxmox: published host + mapped SSH port + key; azure: public host + key). See "Deferred" at the end.
+
+**Note vs spec:** the spec proposed a new `workflow_tasks/infra/ansible/` directory. Since `workflow_tasks/infra/ansible.py` already exists and houses `AnsibleAdapter`, `RunPlaybook` and `install_k6_task` are co-located there (cohesion, no import breakage). Same intent, pragmatic placement.
+
+---
+
+## File Structure
+
+- `tools/workflow-tasks/src/workflow_tasks/infra/ansible.py` — add `run_playbook()` + `install_k6()` to `AnsibleAdapter`; add `RunPlaybook` task and `install_k6_task` factory.
+- `tools/workflow-tasks/src/workflow_tasks/__init__.py` — export `RunPlaybook`, `install_k6_task`.
+- `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py` — new tests for `run_playbook`, `RunPlaybook`, `install_k6_task`.
+- `tools/workflow-tasks/tests/test_public_api.py` — assert new exports.
+- `tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py` — replace bash `InstallK6` instantiation with `install_k6_task(...)`.
+
+---
+
+## Task 1: `AnsibleAdapter.run_playbook` (generic) + `install_k6`
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/infra/ansible.py`
+- Test: `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py`:
+
+```python
+from pathlib import Path
+
+from workflow_tasks.infra.ansible import AnsibleAdapter
+from workflow_tasks.shell import RecordingShell
+from workflow_tasks.vm.models import VmRequest
+
+
+def _external_request() -> VmRequest:
+    return VmRequest(lifecycle="external", host="10.0.0.5", user="ubuntu")
+
+
+def test_run_playbook_builds_ansible_command_and_runs_on_host() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+        private_key_path=Path("/keys/id_ed25519"),
+    )
+
+    adapter.run_playbook(
+        "install-k6.yml",
+        _external_request(),
+        extra_vars={"ansible_port": "2222"},
+    )
+
+    assert len(shell.commands) == 1
+    command = shell.commands[0]
+    assert command[0] == "ansible-playbook"
+    assert "-i" in command and "10.0.0.5," in command
+    assert "-u" in command and "ubuntu" in command
+    assert "--private-key" in command and "/keys/id_ed25519" in command
+    assert "-e" in command and "ansible_port=2222" in command
+    assert command[-1].endswith("playbooks/install-k6.yml")
+
+
+def test_install_k6_uses_install_k6_playbook() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+
+    adapter.install_k6(_external_request())
+
+    assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v`
+Expected: FAIL with `AttributeError: 'AnsibleAdapter' object has no attribute 'run_playbook'` (and `install_k6`).
+
+- [ ] **Step 3: Add `run_playbook` and `install_k6`, refactor typed methods onto `run_playbook`**
+
+In `ansible.py`, add the public method right after `_build_command`:
+
+```python
+    def run_playbook(
+        self,
+        playbook_name: str,
+        request: VmRequest,
+        *,
+        extra_vars: dict[str, str] | None = None,
+        dry_run: bool = False,
+    ) -> ShellExecutionResult:
+        command, env = self._build_command(
+            playbook_name, request, extra_vars=extra_vars, dry_run=dry_run
+        )
+        return self.shell.run(command, cwd=self.repo_root, env=env, dry_run=dry_run)
+
+    def install_k6(
+        self,
+        request: VmRequest,
+        *,
+        dry_run: bool = False,
+    ) -> ShellExecutionResult:
+        return self.run_playbook("install-k6.yml", request, dry_run=dry_run)
+```
+
+Then DRY-refactor the existing typed methods to delegate. For `provision_base` replace its body with:
+
+```python
+    def provision_base(
+        self,
+        request: VmRequest,
+        *,
+        install_helm: bool = False,
+        helm_version: str = "3.16.4",
+        dry_run: bool = False,
+    ) -> ShellExecutionResult:
+        return self.run_playbook(
+            "provision-base.yml",
+            request,
+            extra_vars={
+                "install_helm": str(install_helm).lower(),
+                "helm_version": helm_version.removeprefix("v"),
+                "vm_user": request.user,
+            },
+            dry_run=dry_run,
+        )
+```
+
+Apply the same delegation to `provision_k3s`, `ensure_registry_container`, and `configure_k3s_registry` (replace their `command, env = self._build_command(...)` + `return self.shell.run(...)` bodies with a single `return self.run_playbook(<playbook>, request, extra_vars=<same extra_vars>, dry_run=dry_run)`). Leave `configure_registry` (the two-step composite) unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the existing ansible-adapter test to confirm the refactor is behavior-preserving**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/test_ansible_adapter.py -v`
+Expected: PASS (no regressions in provision_base/provision_k3s/registry behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/infra/ansible.py tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+git commit -m "feat(ansible): add generic AnsibleAdapter.run_playbook + install_k6"
+```
+
+---
+
+## Task 2: `RunPlaybook` task
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/infra/ansible.py`
+- Modify: `tools/workflow-tasks/src/workflow_tasks/__init__.py`
+- Test: `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py`:
+
+```python
+import pytest
+
+from workflow_tasks.infra.ansible import RunPlaybook
+from workflow_tasks.shell import ShellBackend, ShellExecutionResult
+
+
+class _FailingShell(ShellBackend):
+    """Minimal shell that always fails — pattern mirrors tests/infra/test_ansible.py."""
+
+    def run(self, command, *, cwd=None, env=None, dry_run=False) -> ShellExecutionResult:
+        return ShellExecutionResult(command=command, return_code=2, stderr="boom")
+
+
+def test_run_playbook_task_runs_playbook_and_returns_none() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+    task = RunPlaybook(
+        task_id="loadgen.install_k6",
+        title="Install k6 on loadgen VM",
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=_external_request(),
+    )
+
+    assert task.run() is None
+    assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")
+
+
+def test_run_playbook_task_raises_on_nonzero_exit() -> None:
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=_FailingShell(),
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+    task = RunPlaybook(
+        task_id="loadgen.install_k6",
+        title="Install k6",
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=_external_request(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        task.run()
+```
+
+> `RecordingShell` (from `workflow_tasks.shell`) records each invocation in `.commands` (a `list[list[str]]`) and returns `return_code=0`. `ShellExecutionResult` fields: `command, return_code, stdout="", stderr="", dry_run=False, env={}`. Verified against `shellcraft.backend`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v -k RunPlaybook`
+Expected: FAIL with `ImportError: cannot import name 'RunPlaybook'`.
+
+- [ ] **Step 3: Add `RunPlaybook` to `ansible.py`**
+
+Add `from dataclasses import dataclass` to the imports, then at the end of `ansible.py`:
+
+```python
+@dataclass
+class RunPlaybook:
+    """Honest Task that runs an ansible playbook on the host via AnsibleAdapter.
+
+    Connectivity is parametric through the injected adapter (host_resolver +
+    private_key_path) and extra_vars (e.g. ansible_port for non-22 SSH).
+    Satisfies the workflow_tasks.Task protocol; raises on non-zero exit so
+    Workflow.run() stops and triggers cleanup.
+    """
+
+    task_id: str
+    title: str
+    adapter: AnsibleAdapter
+    playbook: str
+    request: VmRequest
+    extra_vars: dict[str, str] | None = None
+
+    def run(self) -> None:
+        result = self.adapter.run_playbook(
+            self.playbook, self.request, extra_vars=self.extra_vars
+        )
+        if result.return_code != 0:
+            raise RuntimeError(
+                result.stderr.strip()
+                or result.stdout.strip()
+                or f"{self.task_id} failed (exit {result.return_code})"
+            )
+```
+
+- [ ] **Step 4: Export from the package `__init__.py`**
+
+In `tools/workflow-tasks/src/workflow_tasks/__init__.py`, after the loadtest import block add:
+
+```python
+from workflow_tasks.infra.ansible import RunPlaybook, install_k6_task
+```
+
+and add `"RunPlaybook", "install_k6_task",` to `__all__` (e.g. at the end of the vm section).
+
+> `install_k6_task` is created in Task 3; importing it here now will fail until Task 3. To keep Task 2 green in isolation, import only `RunPlaybook` here and add `install_k6_task` to the import + `__all__` in Task 3 Step 4.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/infra/ansible.py tools/workflow-tasks/src/workflow_tasks/__init__.py tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+git commit -m "feat(ansible): add RunPlaybook honest task"
+```
+
+---
+
+## Task 3: `install_k6_task` shared factory (the connectivity adapter)
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/infra/ansible.py`
+- Modify: `tools/workflow-tasks/src/workflow_tasks/__init__.py`
+- Test: `tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+from workflow_tasks.infra.ansible import install_k6_task
+
+
+def test_install_k6_task_factory_builds_runplaybook_with_connectivity() -> None:
+    shell = RecordingShell()
+    task = install_k6_task(
+        task_id="loadgen.install_k6",
+        title="Install k6 on loadgen VM",
+        repo_root=Path("/repo"),
+        shell=shell,
+        host="10.0.0.5",
+        user="ubuntu",
+        private_key=Path("/keys/id_ed25519"),
+        port=2222,
+    )
+
+    assert isinstance(task, RunPlaybook)
+    assert task.task_id == "loadgen.install_k6"
+    assert task.playbook == "install-k6.yml"
+
+    task.run()
+    command = shell.commands[0]
+    assert "10.0.0.5," in command
+    assert "ubuntu" in command
+    assert "/keys/id_ed25519" in command
+    assert "ansible_port=2222" in command
+
+
+def test_install_k6_task_factory_omits_port_when_none() -> None:
+    shell = RecordingShell()
+    task = install_k6_task(
+        task_id="loadgen.install_k6",
+        title="Install k6",
+        repo_root=Path("/repo"),
+        shell=shell,
+        host="10.0.0.5",
+        user="ubuntu",
+    )
+    task.run()
+    assert not any("ansible_port=" in arg for arg in shell.commands[0])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v -k install_k6_task`
+Expected: FAIL with `ImportError: cannot import name 'install_k6_task'`.
+
+- [ ] **Step 3: Add the factory to `ansible.py`**
+
+Add `from workflow_tasks.shell import ShellBackend` to imports if not present (it already imports `ShellBackend`). Then append:
+
+```python
+def install_k6_task(
+    *,
+    task_id: str,
+    title: str,
+    repo_root: Path,
+    shell: ShellBackend,
+    host: str,
+    user: str,
+    private_key: Path | None = None,
+    port: int | None = None,
+) -> RunPlaybook:
+    """Build a RunPlaybook for the k6 install against a resolved VM endpoint.
+
+    The single, shared way to install k6 via ansible. Per-lifecycle connectivity
+    is captured as plain arguments:
+      - multipass: host=<resolved IP>, default user, multipass key, port=None
+      - proxmox:   host=<proxmox host>, port=<published SSH port>, proxmox key
+      - azure:     host=<public IP>, azure key, port=None
+    """
+    adapter = AnsibleAdapter(
+        repo_root=repo_root,
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: host,
+        private_key_path=private_key,
+    )
+    request = VmRequest(lifecycle="external", host=host, user=user)
+    extra_vars = {"ansible_port": str(port)} if port is not None else None
+    return RunPlaybook(
+        task_id=task_id,
+        title=title,
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=request,
+        extra_vars=extra_vars,
+    )
+```
+
+- [ ] **Step 4: Add `install_k6_task` to exports**
+
+In `tools/workflow-tasks/src/workflow_tasks/__init__.py`, change the Task-2 import line to:
+
+```python
+from workflow_tasks.infra.ansible import RunPlaybook, install_k6_task
+```
+
+and ensure `__all__` contains both `"RunPlaybook"` and `"install_k6_task"`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Update public-API test**
+
+In `tools/workflow-tasks/tests/test_public_api.py`, add near the existing `assert hasattr(workflow_tasks, "InstallK6")` line:
+
+```python
+    assert hasattr(workflow_tasks, "RunPlaybook")
+    assert hasattr(workflow_tasks, "install_k6_task")
+```
+
+- [ ] **Step 7: Run the public-API + boundary tests**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests/test_public_api.py tools/workflow-tasks/tests/test_package_boundaries.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/infra/ansible.py tools/workflow-tasks/src/workflow_tasks/__init__.py tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py tools/workflow-tasks/tests/test_public_api.py
+git commit -m "feat(ansible): add install_k6_task factory + export"
+```
+
+---
+
+## Task 4: Migrate `two-vm-loadtest` loadgen install to ansible
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py:224-231`
+- Test: `tools/controlplane/tests/test_two_vm_loadtest_plan.py`
+
+Context: `two_vm_loadtest.py` `run()` builds the loadgen `Workflow` (lines ~224-258) with `InstallK6(task_id="loadgen.install_k6", ..., runner=loadgen_runner, remote_dir=remote_home)` as the first task. `loadgen_info` (a `VmInfo` with `.host`) is available from `ensure_loadgen.run()` (line ~168). A freshly-launched multipass VM is reachable by host-side ansible with the user's SSH key — this is how the stack's `vm.provision_base` (ansible) already works.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tools/controlplane/tests/test_two_vm_loadtest_plan.py`:
+
+```python
+def test_two_vm_loadgen_install_uses_runplaybook_not_bash() -> None:
+    """The loadgen install step must be the ansible RunPlaybook, not bash InstallK6."""
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import two_vm_loadtest
+
+    source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_loadtest_plan.py::test_two_vm_loadgen_install_uses_runplaybook_not_bash -v`
+Expected: FAIL — `run()` still contains `InstallK6(` and not `install_k6_task(`.
+
+- [ ] **Step 3: Update imports in `two_vm_loadtest.py`**
+
+In the `from workflow_tasks import (...)` block (lines ~7-18), remove `InstallK6,` and add `install_k6_task,`. Add these imports near the other `from workflow_tasks...` lines:
+
+```python
+from multipass import find_ssh_public_key
+from workflow_tasks.vm.multipass import _find_ssh_private_key_path
+```
+
+- [ ] **Step 4: Replace the bash install task with the factory**
+
+In `run()`, replace the `InstallK6(...)` entry (lines ~226-231) inside the `Workflow(tasks=[...])` with:
+
+```python
+                install_k6_task(
+                    task_id="loadgen.install_k6",
+                    title="Install k6 on loadgen VM",
+                    repo_root=self.runner.paths.workspace_root,
+                    shell=self.runner.shell,
+                    host=loadgen_info.host,
+                    user=request.loadgen_vm.user,
+                    private_key=_find_ssh_private_key_path(find_ssh_public_key()),
+                ),
+```
+
+- [ ] **Step 5: Run the migration test + the existing plan test**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_loadtest_plan.py -v`
+Expected: PASS — both `test_two_vm_loadtest_plan_has_expected_task_ids` (task_id `loadgen.install_k6` still present) and the new RunPlaybook test.
+
+- [ ] **Step 6: Run the broader two-vm + scenario suites**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_loadtest_components.py tools/controlplane/tests/test_two_vm_loadtest_runner.py tools/controlplane/tests/test_scenario_recipes.py -v`
+Expected: PASS (recipe still lists `loadgen.install_k6`; runner/report unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py tools/controlplane/tests/test_two_vm_loadtest_plan.py
+git commit -m "refactor(two-vm-loadtest): install k6 via ansible RunPlaybook"
+```
+
+---
+
+## Task 5: Full suites + deprecation note
+
+**Files:**
+- Modify: `tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py` (docstring only)
+
+- [ ] **Step 1: Mark bash `InstallK6` as deprecated (kept, not deleted)**
+
+In `tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py`, add to the `InstallK6` class docstring:
+
+```python
+@dataclass
+class InstallK6:
+    """DEPRECATED: bash binary-download k6 install (runs on the VM).
+
+    Superseded by the ansible path: ``install_k6_task`` / ``RunPlaybook`` with
+    ``install-k6.yml``. Retained for back-compat until all loadtest scenarios
+    (azure, proxmox) are migrated. Do not use in new code.
+    """
+    task_id: str
+    ...
+```
+
+- [ ] **Step 2: Run the full workflow_tasks suite**
+
+Run: `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests -q`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full controlplane suite**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests -q`
+Expected: PASS. (Per project lore, always run the full controlplane suite even for library changes — `test_milestone_gates.py` / `test_wrapper_docs.py` assert on script existence; this change touches neither, so they should stay green.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
+git commit -m "docs(loadtest): mark bash InstallK6 deprecated in favor of ansible"
+```
+
+---
+
+## Deferred (follow-up plan): azure & proxmox loadgen migration
+
+Not in this plan because accurate code requires first **exposing each orchestrator's loadgen SSH endpoint** for host-side ansible:
+
+- **proxmox** — ansible from host must target the **proxmox host at the published SSH port** (not the guest IP). Prerequisite: resolve `(host, port, key)` for the loadgen VM via the proxmox orchestrator (`_ssh_key(loadgen_request)`, `_published_rule(loadgen_request, "SSH").host_port`) and ensure the loadgen SSH port is published. Then call `install_k6_task(..., host=<proxmox_host>, port=<published_port>, private_key=<key>)` in `proxmox_vm_loadtest.py`'s `_install_k6`.
+- **azure** — confirm `AzureVmOrchestrator` exposes the loadgen VM's public host (`loadgen_info.host`) **and** SSH key path/user. Then call `install_k6_task(..., host=loadgen_info.host, user=..., private_key=<azure key>)` in `azure_vm_loadtest.py`'s `run()`.
+
+Both then update their argv-oracle tests (`test_proxmox_vm_loadtest_plan.py`, `test_azure_vm_loadtest_runner.py`) to expect `ansible-playbook ... install-k6.yml`. The `install_k6_task` factory built here is the shared brick they will reuse.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** RunPlaybook (§4.1) → Tasks 2; generic via AnsibleAdapter.run_playbook → Task 1; TUI integration (§4.2) → satisfied by SubprocessShell live-log streaming (baseline; structured sub-steps noted as future); connectivity adapter (§4.4 Axis B) → `install_k6_task` factory (Task 3); two-vm migration (§4.3) → Task 4; additive/bash kept (§3 goals) → Task 5; azure/proxmox + recipe-fragment composition (§4.4 Axis A, Phase 3) → explicitly Deferred, matching the spec's phasing. Mapping (§2) lives in the committed spec.
+- **Placeholder scan:** no TBD/TODO; all code blocks concrete. The one conditional note (`ScriptedShell` signature) gives the behavioral contract to satisfy.
+- **Type consistency:** `RunPlaybook(task_id, title, adapter, playbook, request, extra_vars)` used identically in Tasks 2/3/4; `install_k6_task(*, task_id, title, repo_root, shell, host, user, private_key=None, port=None)` keyword-only signature used identically in Task 3 tests and Task 4 call site; `AnsibleAdapter.run_playbook(playbook_name, request, *, extra_vars, dry_run)` matches `_build_command`'s existing signature.

--- a/docs/superpowers/specs/2026-06-04-ansible-task-unification-design.md
+++ b/docs/superpowers/specs/2026-06-04-ansible-task-unification-design.md
@@ -1,0 +1,224 @@
+# Ansible Task Unification — Design
+
+**Date:** 2026-06-04
+**Status:** Approved (design), pending implementation plan
+
+## 1. Context & Problem
+
+nanofaas scenarios (e2e, loadtest, cli) are assembled from **components**. Each
+component has a *planner* producing `ScenarioOperation`s, executed through one of
+four mechanisms:
+
+| Mechanism | Meaning | Runs on |
+|---|---|---|
+| **ANSIBLE** | `ansible-playbook X.yml` (playbooks in `workflow_tasks/infra/ansible_assets/`) | host → VM via SSH |
+| **VM-cmd** | tool invocation (`helm`/`docker`/`gradlew`/cli) with `execution_target="vm"` | on the VM via runner |
+| **HOST-cmd** | host CLI (`multipass`/`rsync`/`ssh`/`python -m`) | on the host |
+| **bash-task** | hand-built Python `Task` running a bash one-liner | on the VM via orchestrator |
+
+The provisioning path already standardised on **ansible** (provision_base,
+registry, k3s install, k3s registry config, k6 install — as recipe components).
+The remaining divergence is concentrated and duplicative:
+
+- The **loadgen k6 install** is hand-built as a **bash `InstallK6` task** in three
+  scenarios (`two-vm-loadtest`, `azure-vm-loadtest`, `proxmox-vm-loadtest`),
+  *re-implementing* what the existing `loadgen.install_k6` ansible component
+  (`install-k6.yml`) already does.
+- A **second, divergent bash impl** (apt-based `InstallK6`) lives in
+  `controlplane_tool/scenario/tasks/loadtest.py` (referenced only by tests).
+- Scenarios that are nearly identical duplicate their entire component list
+  (`ScenarioRecipe` is a flat tuple — no composition). The three loadtest
+  recipes are ~22 near-identical `component_ids`; k3s/helm share an 11-component
+  prelude, copied.
+
+**Goal:** establish one way to install k6 (ansible), via a reusable, TUI-aware
+ansible task, additively (without deleting the old bash tasks yet), and lay the
+foundation to collapse near-identical scenarios. Accurate scenario↔component
+mapping is a first-class deliverable.
+
+## 2. Authoritative Mapping
+
+### 2.1 Components × execution mechanism
+
+| Component | Mechanism today | Ansible candidate? |
+|---|---|---|
+| `vm.ensure_running` / `vm.down` | HOST-cmd (`multipass launch`/`delete`) | ❌ lifecycle CLI, not ansible |
+| `vm.provision_base` | ✅ **ANSIBLE** (`provision-base.yml`) | done |
+| `repo.sync_to_vm` | HOST-cmd (rsync) | ⚠️ possible (`synchronize`); low value |
+| `registry.ensure_container` | ✅ **ANSIBLE** (`ensure-registry.yml`) | done |
+| `k3s.install` | ✅ **ANSIBLE** (`provision-k3s.yml`) | done |
+| `k3s.configure_registry` | ✅ **ANSIBLE** (`configure-k3s-registry.yml`) | done |
+| `loadtest.install_k6` / `loadgen.install_k6` | ✅ **ANSIBLE** (`install-k6.yml`) — *as component* | done |
+| `images.build_core.*` / `images.build_selected_functions.*` | VM-cmd (`gradlew`/`docker`) | ⚠️ build logic — low value / high risk |
+| `helm.deploy_control_plane` / `_function_runtime` | VM-cmd (`helm`) | ⚠️ **Phase 3 candidate** (ansible `helm` module) |
+| `namespace.install` / `namespace.uninstall` | VM-cmd (`helm`) | ⚠️ **Phase 3 candidate** |
+| `cleanup.uninstall_*` | VM-cmd (`helm`) | ⚠️ **Phase 3 candidate** |
+| `cli.*` (8 components) | VM-cmd (cli binary) | ❌ this is the SUT |
+| `tests.run_k8s_junit` / `tests.run_k3s_curl_checks` | VM/host-cmd (script / injected) | ❌ verification |
+| `loadgen.run_k6` | HOST/VM-cmd (`k6 run`) | ❌ the test execution itself |
+| `metrics.prometheus_snapshot` / `loadtest.write_report` | HOST-cmd (`python -m`) | ❌ application logic |
+
+### 2.2 Scenarios × execution
+
+| Scenario | Provisioning | Install k6 | Note |
+|---|---|---|---|
+| `k3s-junit-curl` | recipe → `build_command_tasks` (ansible where applicable) | n/a | consistent |
+| `helm-stack` | recipe → `build_command_tasks` | ✅ **ansible** (`loadtest.install_k6` in recipe) | **already unified** |
+| `two-vm-loadtest` | stack: `build_command_tasks` (ansible) | ❌ **bash-task** `InstallK6` (hand-built loadgen Workflow) | diverges |
+| `proxmox-vm-loadtest` | prelude: ansible with `_rewrite_ansible` (SSH port) | ❌ **bash-task** `InstallK6` (in `_ActionTask`) | diverges |
+| `azure-vm-loadtest` | ⚠️ **no provisioning in `run()`** (only ensure VM + k6 workflow) | ❌ **bash-task** `InstallK6` | incomplete/divergent |
+
+**Takeaway:** the only real bash→ansible conversion is the loadgen k6 install,
+duplicated across 3 scenarios (plus the dead apt impl). helm/namespace/cleanup
+are legitimate tool calls documented as Phase-3 ansible candidates.
+
+## 3. Goals / Non-Goals
+
+**Goals**
+- One reusable, generic, TUI-aware ansible task (`RunPlaybook`).
+- Migrate the loadgen k6 install in all 3 loadtest scenarios to `RunPlaybook`.
+- Keep `task_id="loadgen.install_k6"` so dry-run/TUI/task-id assertions are unaffected.
+- Additive: old bash `InstallK6` tasks remain (deprecated, not deleted).
+- Authoritative mapping committed as documentation.
+- Design the bricks (parametric connectivity + recipe fragments) that enable
+  collapsing near-identical scenarios later.
+
+**Non-Goals (this spec)**
+- Deleting the bash tasks.
+- Converting helm/namespace/cleanup to ansible.
+- Fixing azure's missing provisioning.
+- Fully collapsing two-vm/azure/proxmox into one scenario (Phase 3).
+
+## 4. Design
+
+### 4.1 `RunPlaybook` — generic ansible task
+
+New module: `workflow_tasks/infra/ansible/` (new directory, additive).
+
+Signature (illustrative):
+
+```python
+@dataclass
+class RunPlaybook:
+    task_id: str
+    title: str
+    playbook: str                       # e.g. "install-k6.yml" (bundled)
+    host: str                           # resolved IP / hostname (no placeholder)
+    user: str
+    shell: ShellBackend                 # workflow-aware SubprocessShell (host)
+    private_key: Path | None = None
+    port: int | None = None             # proxmox uses a mapped SSH port
+    extra_vars: Mapping[str, str] | None = None
+
+    def run(self) -> None: ...
+```
+
+Behavior:
+- Builds argv:
+  `ansible-playbook -i "<host>," -u <user> [--private-key <key>]
+  [-e ansible_port=<port>] [-e k=v ...] <bundled_ansible_root>/playbooks/<playbook>`
+  with `ANSIBLE_CONFIG=<bundled_ansible_root>/ansible.cfg`.
+- Runs **on the host** via the workflow-aware `SubprocessShell`.
+- Raises on non-zero exit (stderr/stdout in the message).
+- Reuses `bundled_ansible_root()` and the existing playbooks. No new playbooks.
+
+**Connectivity is parametric** (`host/user/key/port`). This is deliberate: it
+turns the per-lifecycle difference (multipass IP / proxmox host+port+key / azure
+host+key) into constructor arguments rather than separate task classes.
+
+### 4.2 TUI integration
+
+`RunPlaybook` runs on `SubprocessShell`, which already routes each output line to
+`workflow_log` when a workflow sink is active → **live ansible output streams to
+the TUI** out of the box (better than the current bash-on-VM task, which goes
+through the orchestrator).
+
+For **phase-level granularity** (one TUI sub-step per ansible task), `RunPlaybook`
+configures a machine-readable ansible callback (e.g. `ANSIBLE_STDOUT_CALLBACK`)
+and maps each parsed ansible task to a nested `step()`/`success()` emitted under
+the parent task (`workflow_step` supports `parent_task_id` nesting). The exact
+granularity (live-log baseline vs full task-level sub-steps) is a plan-level
+detail; the design supports both, with task-level sub-steps as the target.
+
+### 4.3 Scenario migration (loadgen install_k6)
+
+In `two-vm`/`azure`/`proxmox` `run()`, replace the hand-built bash `InstallK6`
+with `RunPlaybook(playbook="install-k6.yml", ...)` instantiated from values each
+scenario already computes:
+
+- **two-vm (multipass):** `host` = resolved loadgen IP (`resolve_multipass_ipv4`
+  of the loadgen VM), `user`/`key` from the loadgen request, no `port`.
+- **proxmox:** `host`/`port`/`key` from the loadgen VM's published SSH endpoint
+  (the same values `_rewrite_ansible` already computes for the stack).
+- **azure:** `host` = `loadgen_info.host`, `user`/`key` from the azure orchestrator.
+
+`task_id` stays `loadgen.install_k6`; titles preserved. The bash `InstallK6`
+classes (workflow_tasks + the dead apt one in controlplane) remain in place,
+deprecated.
+
+### 4.4 Managing near-identical scenarios (foundation for Phase 3)
+
+A scenario is conceptually **`(composed_recipe, connectivity_adapter)`**.
+
+**Axis A — *what* tasks (recipe composition).** Replace flat tuples with named
+fragments composed into recipes:
+
+```
+PROVISION_PRELUDE = (vm.ensure_running, vm.provision_base, repo.sync_to_vm,
+                     registry.ensure_container, images.build_core,
+                     images.build_selected_functions, k3s.install,
+                     k3s.configure_registry, namespace.install,
+                     helm.deploy_control_plane, helm.deploy_function_runtime)
+LOADGEN_SEQUENCE  = (loadgen.ensure_running, loadgen.provision_base,
+                     loadgen.install_k6, loadgen.run_k6,
+                     metrics.prometheus_snapshot, loadtest.write_report, loadgen.down)
+```
+
+- `k3s-junit-curl = PROVISION_PRELUDE + (curl, junit) + cleanup + (vm.down)`
+- `helm-stack = PROVISION_PRELUDE + (loadtest.install_k6, loadtest.run, autoscaling)`
+- `two-vm = azure = proxmox = PROVISION_PRELUDE + CLI + LOADGEN_SEQUENCE + (vm.down)`
+  → **one shared recipe**
+
+A new "similar except 2 tasks" scenario = shared fragment ± a couple entries, not
+a duplicated file.
+
+**Axis B — *how* tasks execute (connectivity).** The three loadtest scenarios
+have the **same** recipe and differ only in SSH connectivity. Because
+`RunPlaybook` takes connectivity as parameters, that difference collapses to a
+small per-lifecycle **connectivity adapter** that yields `(host, user, key, port)`.
+
+**This spec ships the two bricks** (parametric `RunPlaybook`; documented
+fragments). The full collapse (single recipe + connectivity adapters, replacing
+the hand-built loadtest `run()` duplication) is **Phase 3**.
+
+## 5. Phasing
+
+- **Phase 1:** authoritative mapping (this doc) + recipe fragments documented +
+  `RunPlaybook` task with parametric connectivity and TUI integration.
+- **Phase 2:** migrate the loadgen `install_k6` of all 3 loadtest scenarios to
+  `RunPlaybook`; update argv-oracle tests; bash `InstallK6` deprecated (kept).
+- **Phase 3 (documented, not now):** recipe composition + connectivity adapters →
+  collapse near-identical scenarios; evaluate helm/namespace/cleanup via ansible
+  `helm` module; address azure's missing provisioning; remove deprecated bash.
+
+## 6. Testing Strategy
+
+- Unit tests for `RunPlaybook`: argv construction (with/without key/port/extra_vars),
+  `ANSIBLE_CONFIG` env, non-zero-exit raises, TUI event emission.
+- Per-scenario tests: the migrated workflow contains a `RunPlaybook`-backed
+  `loadgen.install_k6` with the correct connectivity; task_ids/titles unchanged.
+- Update existing argv-oracle tests (e.g. proxmox plan) to expect the
+  `ansible-playbook ... install-k6.yml` command.
+- Full controlplane Python suite must pass (incl. milestone/wrapper-doc gates).
+
+## 7. Risks
+
+- **Behavioral change:** install moves from on-VM bash to host-side ansible.
+  Mitigated: multipass + proxmox-stack already do host-ansible today; azure VMs
+  are reachable via public SSH.
+- **Azure connectivity:** verify `AzureVmOrchestrator` exposes user + key path for
+  the loadgen VM before migrating azure (Phase 2 prerequisite).
+- **Proxmox SSH port:** loadgen endpoint (host/port/key) must be resolved the same
+  way the stack endpoint is (`_rewrite_ansible` equivalent for the loadgen VM).
+- **TUI callback parsing:** task-level sub-steps depend on a stable ansible
+  callback format; fall back to live-log streaming if parsing is brittle.

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py
@@ -14,6 +14,7 @@ from workflow_tasks import (
     TimeWindow,
     Workflow,
     WriteK6Report,
+    install_k6_task,
     workflow_step,
 )
 from workflow_tasks.loadtest.models import K6Config, K6Stage
@@ -147,7 +148,15 @@ class AzureVmLoadtestPlan:
 
         workflow = Workflow(
             tasks=[
-                InstallK6(task_id=s_install_k6.task_id, title=s_install_k6.title, runner=loadgen_runner, remote_dir=remote_home),
+                install_k6_task(
+                    task_id=s_install_k6.task_id,
+                    title=s_install_k6.title,
+                    repo_root=self.runner.paths.workspace_root,
+                    shell=self.runner.shell,
+                    host=azure_orch.connection_host(request.loadgen_vm),
+                    user=request.loadgen_vm.user,
+                    private_key=azure_orch.ssh_private_key_path(request.loadgen_vm),
+                ),
                 k6_task,
                 FetchVmResults(task_id=s_fetch.task_id, title=s_fetch.title, fetcher=fetcher, remote_source=remote_paths.summary_path, local_dest=run_dir),
                 CapturePrometheusSnapshot(

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py
@@ -19,6 +19,7 @@ from workflow_tasks import (
     Workflow,
     WriteK6Report,
     command_task_from_operation,
+    install_k6_task,
     workflow_step,
 )
 from workflow_tasks.components.operations import RemoteCommandOperation
@@ -728,11 +729,16 @@ class ProxmoxVmLoadtestPlan:
             )
 
         def _install_k6() -> None:
-            InstallK6(
+            host, port = proxmox_orch.ssh_endpoint(loadgen_request)
+            install_k6_task(
                 task_id=s_install_k6.task_id,
                 title=s_install_k6.title,
-                runner=cast(Any, _loadgen_runner()),
-                remote_dir=state["loadgen_info"].home,
+                repo_root=self.runner.paths.workspace_root,
+                shell=self.runner.shell,
+                host=host,
+                user=loadgen_request.user,
+                private_key=proxmox_orch.ssh_private_key_path(loadgen_request),
+                port=port,
             ).run()
 
         def _run_k6() -> None:

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
@@ -9,16 +9,19 @@ from workflow_tasks import (
     DestroyVm,
     EnsureVmRunning,
     FetchVmResults,
-    InstallK6,
     RunK6,
     TimeWindow,
     Workflow,
+    install_k6_task,
     workflow_step,
     WriteK6Report,
 )
 from workflow_tasks.components.models import ScenarioRecipe
 from workflow_tasks.loadtest.models import K6Config, K6Stage
 from workflow_tasks.vm.models import VmConfig
+from workflow_tasks.vm.multipass import _find_ssh_private_key_path
+
+from multipass import find_ssh_public_key
 
 from controlplane_tool.e2e.e2e_models import E2eRequest
 from controlplane_tool.infra.vm_lifecycle_adapters import MultipassVmAdapter
@@ -223,11 +226,14 @@ class TwoVmLoadtestPlan:
 
         Workflow(
             tasks=[
-                InstallK6(
+                install_k6_task(
                     task_id="loadgen.install_k6",
                     title="Install k6 on loadgen VM",
-                    runner=loadgen_runner,
-                    remote_dir=remote_home,
+                    repo_root=self.runner.paths.workspace_root,
+                    shell=self.runner.shell,
+                    host=loadgen_info.host,
+                    user=request.loadgen_vm.user,
+                    private_key=_find_ssh_private_key_path(find_ssh_public_key()),
                 ),
                 k6_task,
                 FetchVmResults(

--- a/tools/controlplane/tests/test_azure_vm_loadtest_runner.py
+++ b/tools/controlplane/tests/test_azure_vm_loadtest_runner.py
@@ -109,3 +109,13 @@ def test_runner_executes_k6_with_control_plane_url(tmp_path):
     exec_calls = mock_orch.exec_argv.call_args_list
     all_exec_args = " ".join(str(c) for c in exec_calls)
     assert "http://10.0.0.1:30080" in all_exec_args
+
+
+def test_azure_loadgen_install_uses_runplaybook_not_bash() -> None:
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import azure_vm_loadtest
+
+    source = inspect.getsource(azure_vm_loadtest.AzureVmLoadtestPlan.run)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source

--- a/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
@@ -233,6 +233,12 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
 
+        def ssh_endpoint(self, request):
+            return "127.0.0.1", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+
         def teardown(self, request):
             return None
 
@@ -270,7 +276,7 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
         FakeTwoVmLoadtestRunner,
     )
     monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
-    monkeypatch.setattr(proxmox_plan, "InstallK6", FakeTask)
+    monkeypatch.setattr(proxmox_plan, "install_k6_task", FakeTask)
     monkeypatch.setattr(proxmox_plan, "RunK6", FakeTask)
     monkeypatch.setattr(proxmox_plan, "FetchVmResults", FakeTask)
     monkeypatch.setattr(proxmox_plan, "CapturePrometheusSnapshot", FakeTask)
@@ -349,6 +355,12 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
 
+        def ssh_endpoint(self, request):
+            return "127.0.0.1", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+
         def teardown(self, request):
             return None
 
@@ -399,7 +411,7 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
     )
     monkeypatch.setattr(proxmox_plan, "ProxmoxVmAdapter", fake_proxmox_adapter)
     monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
-    monkeypatch.setattr(proxmox_plan, "InstallK6", FakeTask)
+    monkeypatch.setattr(proxmox_plan, "install_k6_task", FakeTask)
     monkeypatch.setattr(proxmox_plan, "RunK6", FakeTask)
     monkeypatch.setattr(proxmox_plan, "FetchVmResults", FakeTask)
     monkeypatch.setattr(proxmox_plan, "CapturePrometheusSnapshot", FakeTask)
@@ -440,3 +452,13 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
     assert adapter_credentials == ["proxmox-stack", "proxmox-loadgen"]
     assert ("proxmox-stack", "proxmox-stack") in ensure_lifecycles
     assert ("proxmox-loadgen", "proxmox-loadgen") in ensure_lifecycles
+
+
+def test_proxmox_loadgen_install_uses_runplaybook_not_bash() -> None:
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import proxmox_vm_loadtest
+
+    source = inspect.getsource(proxmox_vm_loadtest.ProxmoxVmLoadtestPlan._tail_tasks)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source

--- a/tools/controlplane/tests/test_two_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_plan.py
@@ -38,3 +38,14 @@ def test_two_vm_loadtest_plan_has_expected_task_ids() -> None:
     # Cleanup
     assert "vm.loadgen.destroy" in ids
     assert "vm.stack.destroy" in ids
+
+
+def test_two_vm_loadgen_install_uses_runplaybook_not_bash() -> None:
+    """The loadgen install step must be the ansible RunPlaybook, not bash InstallK6."""
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import two_vm_loadtest
+
+    source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
+    assert "install_k6_task(" in source
+    assert "InstallK6(" not in source

--- a/tools/workflow-tasks/src/workflow_tasks/__init__.py
+++ b/tools/workflow-tasks/src/workflow_tasks/__init__.py
@@ -69,7 +69,7 @@ from workflow_tasks.loadtest import (
     WriteK6Report,
     query_prometheus_range_series,
 )
-from workflow_tasks.infra.ansible import RunPlaybook
+from workflow_tasks.infra.ansible import RunPlaybook, install_k6_task
 
 __all__ = [
     "__version__",
@@ -97,6 +97,7 @@ __all__ = [
     "OrchestratorVmRunner", "VmFileFetcher",
     "VmLifecycleAdapter", "MultipassVmAdapter", "AzureVmAdapter", "ProxmoxVmAdapter",
     "RunPlaybook",
+    "install_k6_task",
     # loadtest
     "K6Config", "K6Stage", "K6RunResult", "TimeWindow", "PrometheusQuery",
     "RemoteFileFetcher", "PrometheusClient",

--- a/tools/workflow-tasks/src/workflow_tasks/__init__.py
+++ b/tools/workflow-tasks/src/workflow_tasks/__init__.py
@@ -69,6 +69,7 @@ from workflow_tasks.loadtest import (
     WriteK6Report,
     query_prometheus_range_series,
 )
+from workflow_tasks.infra.ansible import RunPlaybook
 
 __all__ = [
     "__version__",
@@ -95,6 +96,7 @@ __all__ = [
     "MultipassVmProvider", "AzureVmProvider", "ProxmoxVmProvider",
     "OrchestratorVmRunner", "VmFileFetcher",
     "VmLifecycleAdapter", "MultipassVmAdapter", "AzureVmAdapter", "ProxmoxVmAdapter",
+    "RunPlaybook",
     # loadtest
     "K6Config", "K6Stage", "K6RunResult", "TimeWindow", "PrometheusQuery",
     "RemoteFileFetcher", "PrometheusClient",

--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -209,3 +210,32 @@ class AnsibleAdapter:
             registry=registry,
             dry_run=dry_run,
         )
+
+
+@dataclass
+class RunPlaybook:
+    """Honest Task that runs an ansible playbook on the host via AnsibleAdapter.
+
+    Connectivity is parametric through the injected adapter (host_resolver +
+    private_key_path) and extra_vars (e.g. ansible_port for non-22 SSH).
+    Satisfies the workflow_tasks.Task protocol; raises on non-zero exit so
+    Workflow.run() stops and triggers cleanup.
+    """
+
+    task_id: str
+    title: str
+    adapter: AnsibleAdapter
+    playbook: str
+    request: VmRequest
+    extra_vars: dict[str, str] | None = None
+
+    def run(self) -> None:
+        result = self.adapter.run_playbook(
+            self.playbook, self.request, extra_vars=self.extra_vars
+        )
+        if result.return_code != 0:
+            raise RuntimeError(
+                result.stderr.strip()
+                or result.stdout.strip()
+                or f"{self.task_id} failed (exit {result.return_code})"
+            )

--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
@@ -79,6 +79,27 @@ class AnsibleAdapter:
         env = {"ANSIBLE_CONFIG": str(self.ansible_root / "ansible.cfg")}
         return command, env
 
+    def run_playbook(
+        self,
+        playbook_name: str,
+        request: VmRequest,
+        *,
+        extra_vars: dict[str, str] | None = None,
+        dry_run: bool = False,
+    ) -> ShellExecutionResult:
+        command, env = self._build_command(
+            playbook_name, request, extra_vars=extra_vars, dry_run=dry_run
+        )
+        return self.shell.run(command, cwd=self.repo_root, env=env, dry_run=dry_run)
+
+    def install_k6(
+        self,
+        request: VmRequest,
+        *,
+        dry_run: bool = False,
+    ) -> ShellExecutionResult:
+        return self.run_playbook("install-k6.yml", request, dry_run=dry_run)
+
     def _registry_extra_vars(
         self,
         *,
@@ -103,7 +124,7 @@ class AnsibleAdapter:
         helm_version: str = "3.16.4",
         dry_run: bool = False,
     ) -> ShellExecutionResult:
-        command, env = self._build_command(
+        return self.run_playbook(
             "provision-base.yml",
             request,
             extra_vars={
@@ -111,12 +132,6 @@ class AnsibleAdapter:
                 "helm_version": helm_version.removeprefix("v"),
                 "vm_user": request.user,
             },
-            dry_run=dry_run,
-        )
-        return self.shell.run(
-            command,
-            cwd=self.repo_root,
-            env=env,
             dry_run=dry_run,
         )
 
@@ -134,16 +149,10 @@ class AnsibleAdapter:
         }
         if k3s_version:
             extra_vars["k3s_version_override"] = k3s_version
-        command, env = self._build_command(
+        return self.run_playbook(
             "provision-k3s.yml",
             request,
             extra_vars=extra_vars,
-            dry_run=dry_run,
-        )
-        return self.shell.run(
-            command,
-            cwd=self.repo_root,
-            env=env,
             dry_run=dry_run,
         )
 
@@ -155,19 +164,13 @@ class AnsibleAdapter:
         container_name: str = "nanofaas-e2e-registry",
         dry_run: bool = False,
     ) -> ShellExecutionResult:
-        command, env = self._build_command(
+        return self.run_playbook(
             "ensure-registry.yml",
             request,
             extra_vars=self._registry_extra_vars(
                 registry=registry,
                 container_name=container_name,
             ),
-            dry_run=dry_run,
-        )
-        return self.shell.run(
-            command,
-            cwd=self.repo_root,
-            env=env,
             dry_run=dry_run,
         )
 
@@ -178,16 +181,10 @@ class AnsibleAdapter:
         registry: str,
         dry_run: bool = False,
     ) -> ShellExecutionResult:
-        command, env = self._build_command(
+        return self.run_playbook(
             "configure-k3s-registry.yml",
             request,
             extra_vars=self._registry_extra_vars(registry=registry),
-            dry_run=dry_run,
-        )
-        return self.shell.run(
-            command,
-            cwd=self.repo_root,
-            env=env,
             dry_run=dry_run,
         )
 

--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
@@ -239,3 +239,40 @@ class RunPlaybook:
                 or result.stdout.strip()
                 or f"{self.task_id} failed (exit {result.return_code})"
             )
+
+
+def install_k6_task(
+    *,
+    task_id: str,
+    title: str,
+    repo_root: Path,
+    shell: ShellBackend,
+    host: str,
+    user: str,
+    private_key: Path | None = None,
+    port: int | None = None,
+) -> RunPlaybook:
+    """Build a RunPlaybook for the k6 install against a resolved VM endpoint.
+
+    The single, shared way to install k6 via ansible. Per-lifecycle connectivity
+    is captured as plain arguments:
+      - multipass: host=<resolved IP>, default user, multipass key, port=None
+      - proxmox:   host=<proxmox host>, port=<published SSH port>, proxmox key
+      - azure:     host=<public IP>, azure key, port=None
+    """
+    adapter = AnsibleAdapter(
+        repo_root=repo_root,
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: host,
+        private_key_path=private_key,
+    )
+    request = VmRequest(lifecycle="external", host=host, user=user)
+    extra_vars = {"ansible_port": str(port)} if port is not None else None
+    return RunPlaybook(
+        task_id=task_id,
+        title=title,
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=request,
+        extra_vars=extra_vars,
+    )

--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
@@ -93,14 +93,6 @@ class AnsibleAdapter:
         )
         return self.shell.run(command, cwd=self.repo_root, env=env, dry_run=dry_run)
 
-    def install_k6(
-        self,
-        request: VmRequest,
-        *,
-        dry_run: bool = False,
-    ) -> ShellExecutionResult:
-        return self.run_playbook("install-k6.yml", request, dry_run=dry_run)
-
     def _registry_extra_vars(
         self,
         *,

--- a/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
+++ b/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
@@ -53,6 +53,12 @@ def _build_k6_argv(config: "K6Config") -> tuple[str, ...]:
 
 @dataclass
 class InstallK6:
+    """DEPRECATED: bash binary-download k6 install (runs on the VM).
+
+    Superseded by the ansible path: ``install_k6_task`` / ``RunPlaybook`` with
+    ``install-k6.yml``. Retained for back-compat until all loadtest scenarios
+    (azure, proxmox) are migrated. Do not use in new code.
+    """
     task_id: str
     title: str
     runner: "VmCommandRunner"

--- a/tools/workflow-tasks/src/workflow_tasks/vm/azure.py
+++ b/tools/workflow-tasks/src/workflow_tasks/vm/azure.py
@@ -33,6 +33,9 @@ class AzureVmProvider:
             return Path(request.azure_ssh_key_path)
         return _find_ssh_private_key_path()
 
+    def ssh_private_key_path(self, request: VmRequest) -> Path | None:
+        return self._ssh_key(request)
+
     def remote_home(self, request: VmRequest) -> str:
         return vm_remote_home(request)
 

--- a/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
@@ -91,3 +91,45 @@ def test_run_playbook_task_raises_on_nonzero_exit() -> None:
 
     with pytest.raises(RuntimeError, match="boom"):
         task.run()
+
+
+from workflow_tasks.infra.ansible import install_k6_task
+
+
+def test_install_k6_task_factory_builds_runplaybook_with_connectivity() -> None:
+    shell = RecordingShell()
+    task = install_k6_task(
+        task_id="loadgen.install_k6",
+        title="Install k6 on loadgen VM",
+        repo_root=Path("/repo"),
+        shell=shell,
+        host="10.0.0.5",
+        user="ubuntu",
+        private_key=Path("/keys/id_ed25519"),
+        port=2222,
+    )
+
+    assert isinstance(task, RunPlaybook)
+    assert task.task_id == "loadgen.install_k6"
+    assert task.playbook == "install-k6.yml"
+
+    task.run()
+    command = shell.commands[0]
+    assert "10.0.0.5," in command
+    assert "ubuntu" in command
+    assert "/keys/id_ed25519" in command
+    assert "ansible_port=2222" in command
+
+
+def test_install_k6_task_factory_omits_port_when_none() -> None:
+    shell = RecordingShell()
+    task = install_k6_task(
+        task_id="loadgen.install_k6",
+        title="Install k6",
+        repo_root=Path("/repo"),
+        shell=shell,
+        host="10.0.0.5",
+        user="ubuntu",
+    )
+    task.run()
+    assert not any("ansible_port=" in arg for arg in shell.commands[0])

--- a/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
-from workflow_tasks.infra.ansible import AnsibleAdapter
-from workflow_tasks.shell import RecordingShell
+import pytest
+
+from workflow_tasks.infra.ansible import AnsibleAdapter, RunPlaybook
+from workflow_tasks.shell import RecordingShell, ShellBackend, ShellExecutionResult
 from workflow_tasks.vm.models import VmRequest
 
 
@@ -45,3 +47,47 @@ def test_install_k6_uses_install_k6_playbook() -> None:
     adapter.install_k6(_external_request())
 
     assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")
+
+
+class _FailingShell(ShellBackend):
+    """Minimal shell that always fails — pattern mirrors tests/infra/test_ansible.py."""
+
+    def run(self, command, *, cwd=None, env=None, dry_run=False) -> ShellExecutionResult:
+        return ShellExecutionResult(command=command, return_code=2, stderr="boom")
+
+
+def test_run_playbook_task_runs_playbook_and_returns_none() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+    task = RunPlaybook(
+        task_id="loadgen.install_k6",
+        title="Install k6 on loadgen VM",
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=_external_request(),
+    )
+
+    assert task.run() is None
+    assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")
+
+
+def test_run_playbook_task_raises_on_nonzero_exit() -> None:
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=_FailingShell(),
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+    task = RunPlaybook(
+        task_id="loadgen.install_k6",
+        title="Install k6",
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=_external_request(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        task.run()

--- a/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from workflow_tasks.infra.ansible import AnsibleAdapter
+from workflow_tasks.shell import RecordingShell
+from workflow_tasks.vm.models import VmRequest
+
+
+def _external_request() -> VmRequest:
+    return VmRequest(lifecycle="external", host="10.0.0.5", user="ubuntu")
+
+
+def test_run_playbook_builds_ansible_command_and_runs_on_host() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+        private_key_path=Path("/keys/id_ed25519"),
+    )
+
+    adapter.run_playbook(
+        "install-k6.yml",
+        _external_request(),
+        extra_vars={"ansible_port": "2222"},
+    )
+
+    assert len(shell.commands) == 1
+    command = shell.commands[0]
+    assert command[0] == "ansible-playbook"
+    assert "-i" in command and "10.0.0.5," in command
+    assert "-u" in command and "ubuntu" in command
+    assert "--private-key" in command and "/keys/id_ed25519" in command
+    assert "-e" in command and "ansible_port=2222" in command
+    assert command[-1].endswith("playbooks/install-k6.yml")
+
+
+def test_install_k6_uses_install_k6_playbook() -> None:
+    shell = RecordingShell()
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=shell,
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+
+    adapter.install_k6(_external_request())
+
+    assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")

--- a/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
@@ -36,19 +36,6 @@ def test_run_playbook_builds_ansible_command_and_runs_on_host() -> None:
     assert command[-1].endswith("playbooks/install-k6.yml")
 
 
-def test_install_k6_uses_install_k6_playbook() -> None:
-    shell = RecordingShell()
-    adapter = AnsibleAdapter(
-        repo_root=Path("/repo"),
-        shell=shell,
-        host_resolver=lambda request, dry_run=False: "10.0.0.5",
-    )
-
-    adapter.install_k6(_external_request())
-
-    assert shell.commands[0][-1].endswith("playbooks/install-k6.yml")
-
-
 class _FailingShell(ShellBackend):
     """Minimal shell that always fails — pattern mirrors tests/infra/test_ansible.py."""
 

--- a/tools/workflow-tasks/tests/loadtest/test_loadtest_tasks.py
+++ b/tools/workflow-tasks/tests/loadtest/test_loadtest_tasks.py
@@ -62,27 +62,29 @@ def test_install_k6_runs_bash_install_command() -> None:
     assert remote_dir == "/home/ubuntu"
 
 
-def test_install_k6_waits_for_cloud_init_and_apt_locks() -> None:
+def test_install_k6_is_idempotent_and_downloads_binary() -> None:
     runner = _RecordingVmRunner()
     task = InstallK6(task_id="loadgen.install_k6", title="Install k6", runner=runner, remote_dir="/home/ubuntu")
 
     task.run()
 
     command = runner.commands[0][0][-1]
-    assert "cloud-init status --wait" in command
-    assert "/var/lib/apt/lists/lock" in command
-    assert "DPkg::Lock::Timeout=120" in command
-    assert "fi && curl -fsSL" in command
+    assert "which k6 2>/dev/null && exit 0" in command
+    assert "api.github.com/repos/grafana/k6/releases/latest" in command
+    assert "tar -xz" in command
+    assert "/usr/local/bin/k6" in command
 
 
-def test_install_k6_gpg_import_is_non_interactive() -> None:
+def test_install_k6_uses_binary_download_not_apt() -> None:
     runner = _RecordingVmRunner()
     task = InstallK6(task_id="loadgen.install_k6", title="Install k6", runner=runner, remote_dir="/home/ubuntu")
 
     task.run()
 
     command = runner.commands[0][0][-1]
-    assert "sudo gpg --yes --dearmor" in command
+    assert "github.com/grafana/k6/releases/download" in command
+    assert "apt-get install" not in command
+    assert "gpg" not in command
 
 
 def test_install_k6_raises_on_nonzero_exit() -> None:

--- a/tools/workflow-tasks/tests/test_public_api.py
+++ b/tools/workflow-tasks/tests/test_public_api.py
@@ -60,6 +60,8 @@ def test_public_api_exports_loadtest_tasks() -> None:
     assert hasattr(workflow_tasks, "RemoteFileFetcher")
     assert hasattr(workflow_tasks, "PrometheusClient")
     assert hasattr(workflow_tasks, "InstallK6")
+    assert hasattr(workflow_tasks, "RunPlaybook")
+    assert hasattr(workflow_tasks, "install_k6_task")
     assert hasattr(workflow_tasks, "RunK6")
     assert hasattr(workflow_tasks, "FetchVmResults")
     assert hasattr(workflow_tasks, "CapturePrometheusSnapshot")

--- a/tools/workflow-tasks/tests/vm/test_azure_provider.py
+++ b/tools/workflow-tasks/tests/vm/test_azure_provider.py
@@ -95,6 +95,15 @@ def test_ssh_key_fallback(mock_find, mock_client_cls) -> None:
 
 
 @patch("workflow_tasks.vm.azure.AzureClient")
+def test_ssh_private_key_path_public(mock_client_cls, tmp_path) -> None:
+    key = tmp_path / "id_ed25519"
+    key.write_text("x")
+    provider = _make_provider()
+    req = _make_request(azure_ssh_key_path=str(key))
+    assert provider.ssh_private_key_path(req) == key
+
+
+@patch("workflow_tasks.vm.azure.AzureClient")
 def test_connection_host(mock_client_cls) -> None:
     client_mock, vm_mock = _make_azure_client_mock()
     mock_client_cls.return_value = client_mock


### PR DESCRIPTION
## Summary
Establishes **one way** to install k6 — ansible — and lays the foundation for collapsing near-identical loadtest scenarios. Reuses the existing `AnsibleAdapter` (no reinvented command-building).

- **Reusable bricks** (library `workflow_tasks`):
  - `AnsibleAdapter.run_playbook(...)` — public generic playbook runner; the four typed methods (`provision_base`/`provision_k3s`/`ensure_registry_container`/`configure_k3s_registry`) DRY-refactored onto it (behavior-preserving).
  - `RunPlaybook` — thin TUI-aware honest Task (runs on the host shell → live ansible log streaming via `SubprocessShell`; raises on non-zero exit).
  - `install_k6_task(...)` — connectivity-parametric factory `(host, user, private_key, port)`; `port` flows through `-e ansible_port=...`. This is the "connectivity adapter" boundary.
- **Migrations** — loadgen k6 install of all three loadtest scenarios switched from the hand-built bash `InstallK6` to ansible (`install-k6.yml`), `task_id="loadgen.install_k6"` preserved:
  - **two-vm** (multipass): loadgen IP + multipass key.
  - **azure**: `connection_host()` + new public `AzureVmProvider.ssh_private_key_path()`.
  - **proxmox**: `ssh_endpoint()` (proxmox host + published SSH NAT port, not the guest IP) + `ssh_private_key_path()` + port.
- **Additive**: bash `InstallK6` kept but marked **DEPRECATED** (still used only as `_skeleton` task-id/title placeholders). Also fixed two pre-existing stale `test_loadtest_tasks.py` assertions that referenced the old apt/gpg command (replaced by curl/tar in a prior merge).

Out of scope (Phase 3, documented in the spec): recipe-fragment composition to collapse near-identical scenarios, helm/namespace → ansible, and removing the deprecated bash task.

Spec: `docs/superpowers/specs/2026-06-04-ansible-task-unification-design.md`
Plan: `docs/superpowers/plans/2026-06-04-ansible-task-unification.md`

## Test Plan
- [x] `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests -q` → 367 passed, coverage 91.6% (≥90% gate)
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → 1128 passed
- [x] Per-task TDD (failing test first) + two-stage review (spec compliance + code quality) for all 8 tasks + holistic final review
- [ ] Real VM smoke (multipass/azure/proxmox) for the host-side ansible install — not exercised by unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)