### PR TITLE
Loadtest scenario unification: Phase A (recipes) + B1a (ConnectivityStrategy/multipass)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-connectivity-strategy-b1a.md
+++ b/docs/superpowers/plans/2026-06-05-connectivity-strategy-b1a.md
@@ -1,0 +1,391 @@
+# Connectivity Strategy — Phase B1a (Multipass) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a pluggable `ConnectivityStrategy` seam in `build_command_tasks` and provide `MultipassConnectivity` extracting the current multipass behavior, so the produced `CommandTask` argv for every existing scenario is byte-for-byte unchanged (behavior-preserving).
+
+**Architecture:** Move the host-operation resolution + vm-runner wiring out of `build_command_tasks` into a `ConnectivityStrategy` Protocol with a `MultipassConnectivity` implementation that delegates to the existing `resolve_host_operation` (multipass IP placeholder resolution) and `OrchestratorVmRunner`. `build_command_tasks` gains a `connectivity=None` parameter defaulting to `MultipassConnectivity`, so all current callers (k3s-junit-curl, helm-stack, cli-stack, two-vm stack prelude) are unchanged. Argv-golden + existing pinned-argv tests are the safety net.
+
+**Tech Stack:** Python 3.12, `pytest`, `uv`, `workflow_tasks`, `controlplane_tool.scenario`.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-connectivity-strategy-b1-design.md` (Phase B1a). Note: the spec listed a 3-method interface; this plan uses **2 methods** — `resolve_host_operation` already covers both ansible and rsync for multipass (both carry `<multipass-ip:NAME>` placeholders), and `repo_sync_command` is only needed by proxmox in B1b.
+
+**Scope:** ONLY introduce the seam + multipass impl, behavior-preserving. Proxmox (B1b) and azure are out of scope. No scenario `run()` logic changes.
+
+---
+
+## File Structure
+
+- `tools/controlplane/src/controlplane_tool/scenario/connectivity.py` (new) — `ConnectivityStrategy` Protocol, `MultipassConnectivity`, and the moved `resolve_host_operation`.
+- `tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py` — re-export `resolve_host_operation` from `connectivity`; refactor `build_command_tasks` to use a `ConnectivityStrategy`.
+- `tools/controlplane/tests/test_connectivity.py` (new) — unit tests for `MultipassConnectivity`.
+- `tools/controlplane/tests/test_two_vm_stack_prelude_argv.py` (new) — argv golden for the two-vm stack prelude (safety net for the refactor).
+
+---
+
+## Task 1: `ConnectivityStrategy` + `MultipassConnectivity`
+
+**Files:**
+- Create: `tools/controlplane/src/controlplane_tool/scenario/connectivity.py`
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py`
+- Test: `tools/controlplane/tests/test_connectivity.py`
+
+Context: the current `resolve_host_operation` lives in `_workflow_assembly.py` (lines ~124-143):
+
+```python
+def resolve_host_operation(
+    operation: RemoteCommandOperation,
+    *,
+    resolver: CommandResolver,
+    request: E2eRequest,
+    vm: VmOrchestrator,
+    ip_cache: dict[str, str],
+) -> RemoteCommandOperation:
+    """Substitute <multipass-ip:NAME> placeholders in a host operation's argv/env."""
+    argv = resolver._resolve_command(list(operation.argv), request.vm, ip_cache, vm)  # noqa: SLF001
+    env = resolver._resolve_env(dict(operation.env), request.vm, ip_cache, vm)  # noqa: SLF001
+    return RemoteCommandOperation(
+        operation_id=operation.operation_id,
+        summary=operation.summary,
+        argv=tuple(argv),
+        env=env,
+        execution_target=operation.execution_target,
+    )
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tools/controlplane/tests/test_connectivity.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow_tasks.components.operations import RemoteCommandOperation
+from workflow_tasks.shell import RecordingShell
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.e2e.e2e_runner import E2eRunner
+from controlplane_tool.infra.vm.vm_models import VmRequest
+from controlplane_tool.scenario.connectivity import MultipassConnectivity
+
+
+def _runner() -> E2eRunner:
+    return E2eRunner(
+        repo_root=Path("/repo"),
+        shell=RecordingShell(),
+        host_resolver=lambda _request: "10.0.0.9",
+    )
+
+
+def _request() -> E2eRequest:
+    return E2eRequest(
+        scenario="two-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e"),
+    )
+
+
+def test_multipass_connectivity_resolves_host_placeholder() -> None:
+    conn = MultipassConnectivity(runner=_runner(), request=_request())
+    op = RemoteCommandOperation(
+        operation_id="vm.provision_base",
+        summary="Provision",
+        argv=("ansible-playbook", "-i", "<multipass-ip:nanofaas-e2e>,", "provision-base.yml"),
+    )
+
+    resolved = conn.resolve_host_operation(op)
+
+    assert "10.0.0.9," in resolved.argv
+    assert "<multipass-ip:nanofaas-e2e>," not in resolved.argv
+    assert resolved.operation_id == "vm.provision_base"
+
+
+def test_multipass_connectivity_vm_runner_wraps_orchestrator() -> None:
+    runner = _runner()
+    conn = MultipassConnectivity(runner=runner, request=_request())
+
+    vm_runner = conn.vm_runner(VmRequest(lifecycle="multipass", name="nanofaas-e2e"))
+
+    # OrchestratorVmRunner exposes run_vm_command (the VmCommandRunner protocol).
+    assert hasattr(vm_runner, "run_vm_command")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_connectivity.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'controlplane_tool.scenario.connectivity'`.
+
+- [ ] **Step 3: Create `connectivity.py` (move `resolve_host_operation` here + add the strategy)**
+
+Create `tools/controlplane/src/controlplane_tool/scenario/connectivity.py`:
+
+```python
+"""Per-lifecycle connectivity for scenario command execution.
+
+A ConnectivityStrategy supplies the two things that differ between VM lifecycles
+when turning a recipe into honest CommandTasks:
+  - resolve_host_operation: rewrite a host operation's argv/env (ansible inventory,
+    rsync endpoint) to target the VM's SSH endpoint for this lifecycle.
+  - vm_runner: an OrchestratorVmRunner wrapping this lifecycle's orchestrator,
+    used for vm-target operations (helm/docker/gradlew/cli).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from workflow_tasks.components.operations import RemoteCommandOperation
+from workflow_tasks.vm.orchestrator import VmOrchestrator
+from workflow_tasks.vm.runners import OrchestratorVmRunner
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.scenario.command_resolver import CommandResolver
+
+if TYPE_CHECKING:
+    from controlplane_tool.e2e.e2e_runner import E2eRunner
+
+
+def resolve_host_operation(
+    operation: RemoteCommandOperation,
+    *,
+    resolver: CommandResolver,
+    request: E2eRequest,
+    vm: VmOrchestrator,
+    ip_cache: dict[str, str],
+) -> RemoteCommandOperation:
+    """Substitute <multipass-ip:NAME> placeholders in a host operation's argv/env."""
+    argv = resolver._resolve_command(list(operation.argv), request.vm, ip_cache, vm)  # noqa: SLF001
+    env = resolver._resolve_env(dict(operation.env), request.vm, ip_cache, vm)  # noqa: SLF001
+    return RemoteCommandOperation(
+        operation_id=operation.operation_id,
+        summary=operation.summary,
+        argv=tuple(argv),
+        env=env,
+        execution_target=operation.execution_target,
+    )
+
+
+class ConnectivityStrategy(Protocol):
+    def resolve_host_operation(self, operation: RemoteCommandOperation) -> RemoteCommandOperation: ...
+    def vm_runner(self, request: object) -> OrchestratorVmRunner: ...
+
+
+@dataclass
+class MultipassConnectivity:
+    """Current behavior: multipass IP placeholder resolution + multipass orchestrator."""
+
+    runner: "E2eRunner"
+    request: E2eRequest
+    _ip_cache: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+
+    def resolve_host_operation(self, operation: RemoteCommandOperation) -> RemoteCommandOperation:
+        resolver = CommandResolver(host_resolver=self.runner._host_resolver)  # noqa: SLF001
+        return resolve_host_operation(
+            operation,
+            resolver=resolver,
+            request=self.request,
+            vm=self.runner.vm,
+            ip_cache=self._ip_cache,
+        )
+
+    def vm_runner(self, request: object) -> OrchestratorVmRunner:
+        return OrchestratorVmRunner(self.runner.vm, request)
+```
+
+- [ ] **Step 4: Re-export from `_workflow_assembly.py` and delete its local copy**
+
+In `tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py`, DELETE the local `def resolve_host_operation(...)` definition (lines ~124-143) and add, near the other imports at the top:
+
+```python
+from controlplane_tool.scenario.connectivity import (
+    ConnectivityStrategy,
+    MultipassConnectivity,
+    resolve_host_operation,
+)
+```
+
+(The re-export keeps `from ..._workflow_assembly import resolve_host_operation` working for any existing importer.)
+
+- [ ] **Step 5: Run the unit tests + confirm no import breakage**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_connectivity.py tools/controlplane/tests/test_cli_stack_workflow.py tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py -v`
+Expected: PASS (new connectivity tests pass; the cli-stack and proxmox suites still import/run fine).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/connectivity.py tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py tools/controlplane/tests/test_connectivity.py
+git commit -m "feat(scenario): add ConnectivityStrategy + MultipassConnectivity"
+```
+
+---
+
+## Task 2: Route `build_command_tasks` through `ConnectivityStrategy`
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py` (`build_command_tasks`, lines ~242-315)
+- Test: `tools/controlplane/tests/test_two_vm_stack_prelude_argv.py` (new)
+
+- [ ] **Step 1: Write the argv-golden safety net (passes NOW, before the refactor)**
+
+Create `tools/controlplane/tests/test_two_vm_stack_prelude_argv.py`. This is a characterization test: it pins the resolved argv of the two-vm stack prelude with the current machinery and must stay green through the refactor.
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow_tasks.shell import RecordingShell
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.e2e.e2e_runner import E2eRunner
+from controlplane_tool.infra.vm.vm_models import VmRequest
+from controlplane_tool.scenario.scenarios.two_vm_loadtest import build_two_vm_loadtest_plan
+
+
+def _plan():
+    runner = E2eRunner(
+        repo_root=Path("/repo"),
+        shell=RecordingShell(),
+        host_resolver=lambda _request: "10.0.0.9",
+    )
+    request = E2eRequest(
+        scenario="two-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e"),
+        loadgen_vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e-loadgen"),
+    )
+    return build_two_vm_loadtest_plan(runner, request)
+
+
+def test_two_vm_stack_prelude_argv_is_resolved_and_pinned() -> None:
+    plan = _plan()
+    setup = plan._build_setup()  # noqa: SLF001
+    tasks = plan._build_stack_prelude_tasks(setup, resolve_host=True)  # noqa: SLF001
+
+    by_id = {t.task_id: list(t.spec.argv) for t in tasks if getattr(t, "spec", None) is not None}
+
+    # No unresolved multipass placeholders survive in any host command.
+    for task_id, argv in by_id.items():
+        assert not any("<multipass-ip:" in arg for arg in argv), task_id
+
+    # The provision_base ansible command targets the resolved stack IP.
+    provision = by_id["vm.provision_base"]
+    assert provision[0] == "ansible-playbook"
+    assert "10.0.0.9," in provision
+    assert provision[-1].endswith("provision-base.yml")
+```
+
+- [ ] **Step 2: Run it to verify it PASSES now (characterization)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_stack_prelude_argv.py -v`
+Expected: PASS (pins current resolved argv; regression guard for the refactor).
+
+> If `_build_stack_prelude_tasks` / `_build_setup` have different names or signatures, inspect `tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py` and adjust the test to the real API. The contract under test is: the resolved stack-prelude host commands contain the injected IP and no `<multipass-ip:` placeholders.
+
+- [ ] **Step 3: Refactor `build_command_tasks` to use the strategy**
+
+In `_workflow_assembly.py`, replace the `build_command_tasks` body (the part after the docstring) with a version that takes `connectivity` and routes through it. Change the signature to add `connectivity: ConnectivityStrategy | None = None` (keyword-only, after `resolve_host`), and replace the body:
+
+```python
+    context = setup.context
+    vm_request = setup.vm_request
+    vm_orch = runner.vm
+    remote_dir = vm_orch.remote_project_dir(vm_request)
+
+    if connectivity is None:
+        connectivity = MultipassConnectivity(runner=runner, request=request)
+
+    host_executor = HostCommandTaskExecutor(runner.shell)
+    vm_executor = VmCommandTaskExecutor(connectivity.vm_runner(vm_request))
+
+    tasks: list = []
+    for component in compose_recipe(recipe):
+        ctx = context_selector(component) if context_selector is not None else context
+        for operation in component.planner(ctx):
+            if special_handler is not None:
+                result = special_handler(operation)
+                if result is HANDLED:
+                    continue
+                if result is not None:
+                    tasks.append(result)
+                    continue
+            title = _SUMMARY_OVERRIDES.get(operation.operation_id, operation.summary)
+            if operation.execution_target == "vm":
+                tasks.append(
+                    command_task_from_operation(
+                        operation, vm_executor, title=title, remote_dir=remote_dir
+                    )
+                )
+            else:
+                host_op = (
+                    connectivity.resolve_host_operation(operation)
+                    if resolve_host
+                    else operation
+                )
+                tasks.append(
+                    command_task_from_operation(host_op, host_executor, title=title)
+                )
+    return tasks
+```
+
+Also update the signature line to:
+
+```python
+def build_command_tasks(
+    runner: "E2eRunner",
+    request: E2eRequest,
+    setup: _Setup,
+    recipe,
+    *,
+    special_handler: SpecialHandler | None = None,
+    context_selector: Callable[[object], object] | None = None,
+    resolve_host: bool = True,
+    connectivity: ConnectivityStrategy | None = None,
+) -> list:
+```
+
+Remove the now-unused inline `CommandResolver`/`OrchestratorVmRunner`/`resolve_host_operation` usage and the `ip_cache` local from the old body. Keep the existing `from ...command_resolver import CommandResolver` import only if still referenced elsewhere in the file (it is used by `host_command_task_from_step`); leave that import in place.
+
+- [ ] **Step 4: Run the golden + the pinned-argv cli-stack test (must stay green)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_stack_prelude_argv.py tools/controlplane/tests/test_cli_stack_workflow.py tools/controlplane/tests/test_connectivity.py -v`
+Expected: PASS (resolved argv unchanged; `test_workflow_command_tasks_are_resolved_and_pinned` still holds).
+
+- [ ] **Step 5: Run the scenario plan suites**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_two_vm_loadtest_plan.py tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py tools/controlplane/tests/test_helm_stack_workflow.py tools/controlplane/tests/test_scenario_flows.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full controlplane suite**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests -q`
+Expected: PASS (1131+ passed; behavior unchanged — multipass path is the default).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py tools/controlplane/tests/test_two_vm_stack_prelude_argv.py
+git commit -m "refactor(scenario): build_command_tasks routes via ConnectivityStrategy"
+```
+
+---
+
+## Real-VM validation (user, after merge of the branch)
+
+B1a is behavior-preserving for multipass, but the only true proof is a real run. Before
+trusting B1 end to end, run `two-vm-loadtest` on real multipass VMs (e.g.
+`./scripts/controlplane.sh e2e run two-vm-loadtest` or the project's documented entrypoint)
+and confirm it provisions + runs k6 as before. This is not a CI gate; it is the manual
+validation the spec requires for the multipass lifecycle.
+
+---
+
+## Self-Review
+
+- **Spec coverage (B1 §3.1/§3.2/§3.3 B1a):** `ConnectivityStrategy` Protocol (Task 1); `MultipassConnectivity` extracting current behavior via the moved `resolve_host_operation` + `OrchestratorVmRunner` (Task 1); `build_command_tasks` takes the strategy, defaulting to multipass so all callers are unchanged (Task 2). Proxmox/azure explicitly out of scope (stated). Interface simplified to 2 methods vs the spec's 3 — documented in the header (repo_sync_command deferred to B1b).
+- **Placeholder scan:** no TBD/TODO; full code for `connectivity.py` and the refactored `build_command_tasks` body provided; the one conditional note (Task 2 Step 2) gives the behavioral contract if the two-vm plan API differs.
+- **Type consistency:** `ConnectivityStrategy.resolve_host_operation(op) -> RemoteCommandOperation` and `.vm_runner(request) -> OrchestratorVmRunner` used identically in `MultipassConnectivity` and in `build_command_tasks`; the moved module-level `resolve_host_operation(operation, *, resolver, request, vm, ip_cache)` keeps its original signature so `MultipassConnectivity` and any re-export consumer call it the same way.
+- **Behavior preservation:** guaranteed by (a) `MultipassConnectivity` delegating to the unchanged `resolve_host_operation`, (b) the default making every existing caller use multipass, (c) the existing pinned-argv `test_cli_stack_workflow` + the new two-vm argv golden, (d) the full suite, (e) the user's real-multipass run.

--- a/docs/superpowers/plans/2026-06-05-recipe-fragment-composition.md
+++ b/docs/superpowers/plans/2026-06-05-recipe-fragment-composition.md
@@ -1,0 +1,307 @@
+# Recipe-Fragment Composition (Phase A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the six flat-tuple `ScenarioRecipe` definitions in `recipes.py` with composition from named fragments, producing byte-for-byte identical `component_ids` (behavior-preserving), and collapsing the three near-identical loadtest recipes into one shared definition.
+
+**Architecture:** Define module-level fragment tuples (`BASE_PROVISION`, `STACK_PRELUDE`, `LOADTEST_TAIL`) in `recipes.py` and build each recipe by tuple concatenation `fragment + delta`. A golden characterization test pins the exact current `component_ids` of all six scenarios as the regression guard. No execution changes; this is Phase A of the loadtest-scenario-unification spec.
+
+**Tech Stack:** Python 3.12, `pytest`, `uv`, `workflow_tasks.components.models.ScenarioRecipe`.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-loadtest-scenario-unification-design.md` (§2.1, §3 Phase A).
+
+**Scope:** ONLY `tools/controlplane/src/controlplane_tool/scenario/components/recipes.py`. The scenarios' hand-built prelude tuples (`_TWO_VM_STACK_PRELUDE_COMPONENTS`, `_PROXMOX_LOADTEST_PRELUDE_COMPONENTS`) are NOT touched here — they feed execution and are handled in Phase B1. This plan changes no runtime behavior.
+
+---
+
+## File Structure
+
+- `tools/controlplane/src/controlplane_tool/scenario/components/recipes.py` — add fragment constants; rebuild `_SCENARIO_RECIPES` via composition. `build_scenario_recipe` unchanged.
+- `tools/controlplane/tests/test_recipe_fragments.py` (new) — golden component_ids guard + loadtest-recipes-identical assertion.
+
+---
+
+## Task 1: Golden characterization test (regression guard)
+
+This is a characterization test: it pins the CURRENT exact `component_ids` of all six recipes and PASSES immediately (before any refactor). It is the safety net that guarantees Task 2's refactor is byte-for-byte behavior-preserving.
+
+**Files:**
+- Create: `tools/controlplane/tests/test_recipe_fragments.py`
+
+- [ ] **Step 1: Write the golden test**
+
+```python
+from __future__ import annotations
+
+from controlplane_tool.scenario.components.recipes import build_scenario_recipe
+
+# Golden snapshot of every scenario's exact component_ids as of 2026-06-05.
+# This pins current behavior so the fragment refactor (Task 2) stays byte-for-byte identical.
+GOLDEN: dict[str, tuple[str, ...]] = {
+    "k3s-junit-curl": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "tests.run_k3s_curl_checks", "tests.run_k8s_junit",
+        "cleanup.uninstall_function_runtime", "cleanup.uninstall_control_plane",
+        "namespace.uninstall", "vm.down",
+    ),
+    "helm-stack": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "loadtest.install_k6", "loadtest.run", "experiments.autoscaling",
+    ),
+    "two-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "azure-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "proxmox-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "cli-stack": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "cli.build_install_dist", "cli.platform_install", "cli.platform_status",
+        "cli.fn_apply_selected", "cli.fn_list_selected", "cli.fn_invoke_selected",
+        "cli.fn_enqueue_selected", "cli.fn_delete_selected",
+        "cleanup.uninstall_control_plane", "namespace.uninstall",
+        "cleanup.verify_cli_platform_status_fails", "vm.down",
+    ),
+}
+
+
+def test_recipe_component_ids_match_golden() -> None:
+    for name, expected in GOLDEN.items():
+        assert build_scenario_recipe(name).component_ids == expected, name
+
+
+def test_all_recipes_have_golden_entry() -> None:
+    # Guard against a new scenario being added without updating the golden snapshot.
+    from controlplane_tool.scenario.components.recipes import _SCENARIO_RECIPES
+
+    assert set(_SCENARIO_RECIPES) == set(GOLDEN)
+```
+
+- [ ] **Step 2: Run the test to verify it PASSES now (characterization)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_recipe_fragments.py -v`
+Expected: PASS (it pins current behavior; this is a regression guard, not red-green TDD).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/controlplane/tests/test_recipe_fragments.py
+git commit -m "test(recipes): golden component_ids guard before fragment refactor"
+```
+
+---
+
+## Task 2: Compose recipes from fragments
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/components/recipes.py`
+- Test: `tools/controlplane/tests/test_recipe_fragments.py`
+
+- [ ] **Step 1: Add a test asserting the three loadtest recipes are identical**
+
+Append to `tools/controlplane/tests/test_recipe_fragments.py`:
+
+```python
+def test_loadtest_recipes_are_identical() -> None:
+    # The fragment refactor collapses the three loadtest recipes to one shared definition.
+    two_vm = build_scenario_recipe("two-vm-loadtest").component_ids
+    azure = build_scenario_recipe("azure-vm-loadtest").component_ids
+    proxmox = build_scenario_recipe("proxmox-vm-loadtest").component_ids
+    assert two_vm == azure == proxmox
+```
+
+- [ ] **Step 2: Run it to verify it passes (they are already identical today)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_recipe_fragments.py::test_loadtest_recipes_are_identical -v`
+Expected: PASS (the three tuples are already equal; this locks the intent for the refactor).
+
+- [ ] **Step 3: Rewrite `recipes.py` using fragment composition**
+
+Replace the entire body of `tools/controlplane/src/controlplane_tool/scenario/components/recipes.py` with:
+
+```python
+from __future__ import annotations
+
+from workflow_tasks.components.models import ScenarioRecipe
+
+# ── Reusable recipe fragments ────────────────────────────────────────────────
+# Provisioning shared by every managed-VM scenario, up to and including the
+# namespace Helm release (the last step before scenarios diverge).
+BASE_PROVISION: tuple[str, ...] = (
+    "vm.ensure_running",
+    "vm.provision_base",
+    "repo.sync_to_vm",
+    "registry.ensure_container",
+    "images.build_core",
+    "images.build_selected_functions",
+    "k3s.install",
+    "k3s.configure_registry",
+    "namespace.install",
+)
+
+# Deploy nanofaas via Helm (control-plane + function-runtime). Used by every
+# scenario except cli-stack, which installs through the CLI instead.
+HELM_DEPLOY: tuple[str, ...] = (
+    "helm.deploy_control_plane",
+    "helm.deploy_function_runtime",
+)
+
+# Full Helm-based stack prelude (provision + deploy).
+STACK_PRELUDE: tuple[str, ...] = BASE_PROVISION + HELM_DEPLOY
+
+# Shared tail for the loadgen-based loadtest scenarios: build the CLI, register
+# functions, then run the k6 load test from the loadgen VM and tear down.
+LOADTEST_TAIL: tuple[str, ...] = (
+    "cli.build_install_dist",
+    "cli.fn_apply_selected",
+    "loadgen.ensure_running",
+    "loadgen.provision_base",
+    "loadgen.install_k6",
+    "loadgen.run_k6",
+    "metrics.prometheus_snapshot",
+    "loadtest.write_report",
+    "loadgen.down",
+    "vm.down",
+)
+
+# The three loadtest scenarios share one recipe shape (they differ only by
+# lifecycle/connectivity at execution time, not by component list).
+_LOADTEST_COMPONENT_IDS: tuple[str, ...] = STACK_PRELUDE + LOADTEST_TAIL
+
+
+def _loadtest_recipe(name: str) -> ScenarioRecipe:
+    return ScenarioRecipe(
+        name=name,
+        component_ids=_LOADTEST_COMPONENT_IDS,
+        requires_managed_vm=True,
+    )
+
+
+_SCENARIO_RECIPES: dict[str, ScenarioRecipe] = {
+    "k3s-junit-curl": ScenarioRecipe(
+        name="k3s-junit-curl",
+        component_ids=STACK_PRELUDE
+        + (
+            "tests.run_k3s_curl_checks",
+            "tests.run_k8s_junit",
+            "cleanup.uninstall_function_runtime",
+            "cleanup.uninstall_control_plane",
+            "namespace.uninstall",
+            "vm.down",
+        ),
+        requires_managed_vm=True,
+    ),
+    "helm-stack": ScenarioRecipe(
+        name="helm-stack",
+        component_ids=STACK_PRELUDE
+        + (
+            "loadtest.install_k6",
+            "loadtest.run",
+            "experiments.autoscaling",
+        ),
+        requires_managed_vm=True,
+    ),
+    "two-vm-loadtest": _loadtest_recipe("two-vm-loadtest"),
+    "azure-vm-loadtest": _loadtest_recipe("azure-vm-loadtest"),
+    "proxmox-vm-loadtest": _loadtest_recipe("proxmox-vm-loadtest"),
+    "cli-stack": ScenarioRecipe(
+        name="cli-stack",
+        component_ids=BASE_PROVISION
+        + (
+            "cli.build_install_dist",
+            "cli.platform_install",
+            "cli.platform_status",
+            "cli.fn_apply_selected",
+            "cli.fn_list_selected",
+            "cli.fn_invoke_selected",
+            "cli.fn_enqueue_selected",
+            "cli.fn_delete_selected",
+            "cleanup.uninstall_control_plane",
+            "namespace.uninstall",
+            "cleanup.verify_cli_platform_status_fails",
+            "vm.down",
+        ),
+        requires_managed_vm=True,
+    ),
+}
+
+
+def build_scenario_recipe(name: str) -> ScenarioRecipe:
+    try:
+        recipe = _SCENARIO_RECIPES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported scenario recipe: {name}") from exc
+
+    return ScenarioRecipe(
+        name=recipe.name,
+        component_ids=tuple(recipe.component_ids),
+        requires_managed_vm=recipe.requires_managed_vm,
+    )
+```
+
+- [ ] **Step 4: Run the golden + identity tests (must stay green)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_recipe_fragments.py -v`
+Expected: PASS (golden component_ids unchanged; loadtest recipes identical).
+
+- [ ] **Step 5: Run the existing recipe + scenario suites (no regressions)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests/test_scenario_recipes.py tools/controlplane/tests/test_scenario_component_library.py tools/controlplane/tests/test_two_vm_loadtest_plan.py tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py tools/controlplane/tests/test_e2e_catalog.py -v`
+Expected: PASS (membership/ordering tests still hold because component_ids are byte-for-byte identical).
+
+- [ ] **Step 6: Run the full controlplane suite (final safety net)**
+
+Run: `cd /Users/micheleciavotta/Downloads/mcFaas && uv run --project tools/controlplane pytest tools/controlplane/tests -q`
+Expected: PASS (1128+ passed; no behavior changed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/controlplane/src/controlplane_tool/scenario/components/recipes.py tools/controlplane/tests/test_recipe_fragments.py
+git commit -m "refactor(recipes): compose scenario recipes from shared fragments"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (§2.1, §3 Phase A):** fragments `BASE_PROVISION`/`STACK_PRELUDE`/`LOADTEST_TAIL` defined (Task 2 Step 3); `recipes.py` rebuilt as fragment+delta; three loadtest recipes collapsed to one shared `_LOADTEST_COMPONENT_IDS` (Task 2) with an explicit identity test; behavior-preserving guaranteed by the golden test (Task 1). The hand-built scenario prelude tuples are explicitly deferred to Phase B1 (stated in Scope) — not a gap.
+- **Placeholder scan:** no TBD/TODO; the full replacement body of `recipes.py` is provided verbatim; golden tuples transcribed from the current file.
+- **Type consistency:** fragments are `tuple[str, ...]`; `STACK_PRELUDE = BASE_PROVISION + HELM_DEPLOY` and `_LOADTEST_COMPONENT_IDS = STACK_PRELUDE + LOADTEST_TAIL` are tuple concatenations; `build_scenario_recipe` signature/behavior unchanged; `ScenarioRecipe(name, component_ids, requires_managed_vm)` matches `workflow_tasks.components.models.ScenarioRecipe`.
+- **Manual cross-check of composition vs golden:**
+  - k3s-junit-curl = STACK_PRELUDE(11) + 6 = 17 ✓
+  - helm-stack = STACK_PRELUDE(11) + 3 = 14 ✓
+  - two-vm/azure/proxmox = STACK_PRELUDE(11) + LOADTEST_TAIL(10) = 21 ✓
+  - cli-stack = BASE_PROVISION(9) + 12 = 21 ✓

--- a/docs/superpowers/specs/2026-06-05-connectivity-strategy-b1-design.md
+++ b/docs/superpowers/specs/2026-06-05-connectivity-strategy-b1-design.md
@@ -1,0 +1,109 @@
+# Connectivity Strategy (Phase B1) — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (design). Part of the loadtest-scenario-unification roadmap
+(`2026-06-05-loadtest-scenario-unification-design.md`, Phase B1).
+
+## 1. Goal
+
+Replace the hard-coded multipass connectivity in the scenario execution machinery
+(`build_command_tasks`) with a pluggable, per-lifecycle **`ConnectivityStrategy`**, and
+route the **proxmox** loadtest prelude through that same unified machinery — retiring
+proxmox's bespoke `_build_prelude_tasks` / `_rewrite_ansible`. **Azure is deferred** (its
+provisioning is new behavior that cannot be validated on real VMs right now).
+
+## 2. Background: what differs at execution time
+
+Scenario recipes are turned into honest `CommandTask`s by `build_command_tasks`
+(`scenario/scenarios/_workflow_assembly.py`). Operations route by `execution_target`:
+
+- **vm-ops** (`helm`, `docker`, `gradlew`, the CLI binary) run via
+  `VmCommandTaskExecutor(OrchestratorVmRunner(orch, request))`. The orchestrator already
+  abstracts SSH for all three lifecycles, so **vm-ops are already lifecycle-agnostic** —
+  the only variable is *which* orchestrator builds the runner.
+- **host-ops** (`ansible-playbook`, `rsync` for `repo.sync_to_vm`) run on the host shell
+  and must target the VM's SSH endpoint. This is the part that differs:
+  - **multipass:** `<multipass-ip:NAME>` placeholders resolved to the VM IP by
+    `CommandResolver` (current behavior in `resolve_host_operation`).
+  - **proxmox:** ansible inventory rewritten to the NAT host + `-e ansible_port=<port>` +
+    `--private-key`; rsync rebuilt over `host:port` with the key (`_rewrite_ansible` /
+    `_repo_sync_command` in `proxmox_vm_loadtest.py`).
+  - **azure:** public host + key (no provisioning exists today — out of scope here).
+
+proxmox additionally substitutes `cli.fn_apply_selected` → a REST `functions.register`
+step for loadtest scenarios. That is a *recipe/component* concern, not connectivity;
+`build_command_tasks` already supports it via its existing `special_handler` parameter.
+
+## 3. Design
+
+### 3.1 `ConnectivityStrategy` (the seam)
+A small interface (in `controlplane_tool/scenario`, next to `build_command_tasks`):
+
+```python
+class ConnectivityStrategy(Protocol):
+    def resolve_ansible_operation(self, op: RemoteCommandOperation) -> RemoteCommandOperation: ...
+    def repo_sync_command(self, *, repo_root: Path, destination: str) -> list[str]: ...
+    def vm_runner(self, request) -> VmCommandRunner: ...
+```
+
+- `resolve_ansible_operation` — rewrite the host ansible op's inventory/port/key for this
+  lifecycle.
+- `repo_sync_command` — the rsync argv for `repo.sync_to_vm` for this lifecycle.
+- `vm_runner` — `OrchestratorVmRunner` wrapping this lifecycle's orchestrator, for vm-ops.
+
+`build_command_tasks` takes a `ConnectivityStrategy` and routes:
+host ansible-op → `resolve_ansible_operation`; `repo.sync_to_vm` → `repo_sync_command`;
+vm-op → `vm_runner`. Its existing `special_handler` / `context_selector` parameters are
+retained for scenario-specific operations (e.g. proxmox's `functions.register`).
+
+### 3.2 Implementations
+- **`MultipassConnectivity`** — extracts the current behavior verbatim: `resolve_host_operation`
+  via `CommandResolver` (`<multipass-ip:NAME>` → IP); the current multipass rsync builder;
+  `vm_runner` over the multipass `VmOrchestrator`. **Behavior-preserving.**
+- **`ProxmoxConnectivity`** — extracts proxmox's `_rewrite_ansible` (NAT host + `ansible_port`
+  + `--private-key`) and `_repo_sync_command`; `vm_runner` over the proxmox orchestrator.
+  Endpoint (`host`, `port`, `key`) comes from the proxmox orchestrator's public
+  `ssh_endpoint()` / `ssh_private_key_path()`. **Argv-preserving** (same commands as today).
+- **Azure** — deferred. Azure scenario `run()` is untouched in B1.
+
+### 3.3 Migration
+- **B1a — Strategy + Multipass:** introduce `ConnectivityStrategy`; refactor
+  `build_command_tasks` to take it; provide `MultipassConnectivity` as the default used by
+  the recipe-driven scenarios (k3s-junit-curl, helm-stack, cli-stack) and two-vm's stack
+  prelude. The produced argv for every existing scenario stays identical.
+- **B1b — Proxmox:** add `ProxmoxConnectivity`; route the proxmox loadtest prelude through
+  `build_command_tasks` with that strategy + a `special_handler` for `functions.register`;
+  retire `_build_prelude_tasks` / `_rewrite_ansible` / `_repo_sync_command`. Proxmox's
+  produced argv stays identical to today.
+
+## 4. Testing Strategy
+
+- **Argv golden / characterization tests (CI):** the safety net for a behavior-preserving
+  refactor with no real-VM coverage. Pin the exact argv (and env) each scenario's prelude
+  produces *before* the refactor; assert the unified machinery produces identical argv
+  *after*. This is how proxmox is guarded without a real Proxmox.
+  - multipass scenarios: characterize k3s-junit-curl / helm-stack / cli-stack / two-vm
+    stack-prelude command argv.
+  - proxmox: characterize the proxmox prelude command argv (inventory/port/key/rsync).
+- **Unit tests:** each `ConnectivityStrategy` impl (ansible rewrite, repo_sync_command,
+  vm_runner wiring) tested in isolation with recording shells / fakes.
+- **Real-VM validation (user-run, NOT CI):** multipass — run `two-vm-loadtest` end to end
+  on real multipass VMs to confirm B1a is genuinely behavior-preserving. Proxmox/azure are
+  NOT validated; the PR must state this explicitly.
+
+## 5. Risks
+- **No CI e2e coverage** — argv golden tests prove the commands are unchanged, not that the
+  flow works. Mitigation: real multipass run for the validatable path; argv-identity for
+  proxmox.
+- **proxmox entanglement** — its prelude builder mixes connectivity, repo-sync, and the
+  `functions.register` substitution. B1b must move each concern to the right seam
+  (strategy vs special_handler) without changing produced argv. Golden test guards this.
+- **Scope discipline** — B1 is connectivity only. The canonical-recipe function-registration
+  change for two-vm/azure (so all three register the same way) is **not** B1 — it lands in
+  the later loadgen-collapse phase. B1 keeps each scenario's current behavior.
+
+## 6. Out of Scope
+- Azure provisioning / azure routing through the unified machinery — deferred until real-VM
+  validation is possible.
+- The shared loadgen sequence (Phase B2) and final scenario collapse (B3).
+- Canonicalizing function registration across the three loadtest scenarios.

--- a/docs/superpowers/specs/2026-06-05-loadtest-scenario-unification-design.md
+++ b/docs/superpowers/specs/2026-06-05-loadtest-scenario-unification-design.md
@@ -1,0 +1,136 @@
+# Loadtest Scenario Unification — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (design), phased; Phase A goes to a plan first.
+
+## 1. Context & Problem
+
+The three VM loadtest scenarios — `two-vm-loadtest` (multipass), `azure-vm-loadtest`,
+`proxmox-vm-loadtest` — are conceptually the same e2e flow (provision a k3s stack,
+deploy nanofaas, register functions, run a k6 load test from a separate loadgen VM,
+capture Prometheus, report) but are implemented three different ways. Investigation
+(2026-06-05) shows the divergence is **accidental drift, not principled difference**:
+
+| Aspect | two-vm | proxmox | azure |
+|---|---|---|---|
+| Stack prelude | 10 components (`provision_base`→`helm.deploy_function_runtime`), hand-built | same 10 + `vm.ensure_running` | **none** (no k3s/helm/images at all) |
+| Function registration | **none** in `run()` (recipe lists `cli.*` but execution skips it) | `cli.fn_apply_selected` substituted by REST `functions.register` for loadtest | none |
+| Loadgen sequence | `Workflow([install_k6, run_k6, fetch, prom, report])` + cleanup | same steps but wrapped in `_ActionTask` + lazy `state` dict | identical to two-vm |
+| Connectivity | multipass IP (`<multipass-ip:NAME>` via `CommandResolver`) | proxmox NAT host + published SSH port (`_rewrite_ansible`) | public host |
+| Execution machinery | `build_command_tasks` (recipe→CommandTasks) for stack; hand-built loadgen | bespoke `_build_prelude_tasks` + `_rewrite_ansible`; hand-built loadgen | fully hand-built; no recipe execution |
+
+**Key findings:**
+- **two-vm silently skips function registration** — its `run()` registers no functions
+  even though its recipe lists `cli.build_install_dist` + `cli.fn_apply_selected`. This is
+  a drift/bug, not a design choice.
+- **azure has no provisioning at all** — it can only work against a pre-provisioned
+  stack that nothing sets up. A gap.
+- The **only legitimate difference is connectivity** (multipass IP / proxmox NAT / azure
+  public host) — exactly what the k6 work (PR #97) already abstracted as parameters.
+- `recipes.py` duplicates the 11-component prelude across 6 recipes (flat tuples, no
+  composition); the three loadtest recipes are ~21–22 near-identical `component_ids`.
+
+**Goal:** collapse the three loadtest scenarios into instances of **one** flow that
+differs only by a per-lifecycle connectivity adapter, fixing the drift (two-vm gains
+function registration; azure gains provisioning) and removing the duplication.
+
+## 2. Target Architecture
+
+A loadtest scenario = **`(canonical_recipe, ConnectivityAdapter)`**.
+
+### 2.1 Canonical loadtest recipe (composed from fragments)
+Adopt the proxmox superset as canonical:
+
+```
+PROVISION_PRELUDE = (vm.ensure_running, vm.provision_base, repo.sync_to_vm,
+                     registry.ensure_container, images.build_core,
+                     images.build_selected_functions, k3s.install,
+                     k3s.configure_registry, namespace.install,
+                     helm.deploy_control_plane, helm.deploy_function_runtime)
+FUNCTION_SETUP    = (cli.build_install_dist, cli.fn_apply_selected)   # see note
+LOADGEN_SEQUENCE  = (loadgen.ensure_running, loadgen.install_k6, loadgen.run_k6,
+                     metrics.prometheus_snapshot, loadtest.write_report, loadgen.down)
+TEARDOWN          = (vm.down,)
+
+LOADTEST_RECIPE = PROVISION_PRELUDE + FUNCTION_SETUP + LOADGEN_SEQUENCE + TEARDOWN
+```
+
+**Note on function registration:** in loadtest scenarios, `cli.fn_apply_selected` is
+executed as a REST `functions.register` step (proxmox's existing behavior), not a CLI
+call. The canonical flow keeps this substitution. `loadgen.provision_base` is included
+where the lifecycle needs it (multipass loadgen is reachable for ansible without it; kept
+optional per adapter).
+
+### 2.2 `ConnectivityAdapter` (the one legitimate difference)
+A per-lifecycle adapter supplying everything that differs between multipass/azure/proxmox:
+
+- `lifecycle` — the `VmLifecycleAdapter` (ensure/destroy) for stack and loadgen.
+- `vm` / runner+fetcher — the orchestrator for `OrchestratorVmRunner` / `VmFileFetcher`.
+- `stack_host(stack_request, stack_info)` and `loadgen_endpoint(loadgen_request, loadgen_info) -> (host, user, key, port)` — host/port/key resolution for ansible/k6 (multipass IP; proxmox NAT host+port; azure public host).
+- `control_plane_url(...)` / `prometheus_url(...)` — URL sources (proxmox publishes a Prometheus NodePort).
+- `prepare()` / per-step hooks — e.g. proxmox `publish_ports` (NAT) before loadgen.
+
+### 2.3 One execution machinery
+`build_command_tasks` / host-operation resolution is extended to take a **connectivity
+strategy** instead of hard-coding multipass `<multipass-ip:NAME>` resolution. The same
+recipe then runs through the same machinery for all three lifecycles. The live loadgen
+tasks (`RunK6`/`FetchVmResults`/`CapturePrometheusSnapshot`/`WriteK6Report`) move into a
+**shared loadgen-sequence builder** parametrized by the adapter, replacing the three
+hand-built `run()` blocks. proxmox's bespoke `_build_prelude_tasks` + `_rewrite_ansible`
+and its `_ActionTask`/lazy-`state` pattern are retired in favor of the shared path.
+
+## 3. Phased Roadmap
+
+Too large for one plan. Each phase is its own plan/implementation cycle. Phase A first.
+
+- **Phase A — Recipe-fragment composition** *(low risk, behavior-preserving)*
+  Introduce named fragments and rebuild `recipes.py` (and the scenarios' hand-built
+  prelude tuples) as `fragment + delta`. The produced `component_ids` for every scenario
+  stay **identical** to today, so existing task-id/ordering/recipe tests are the safety
+  net. Delivers the dedup of §1's recipe duplication and makes the canonical recipe
+  expressible. No execution changes.
+
+- **Phase B1 — Connectivity strategy in the execution machinery**
+  Extend `build_command_tasks` / `resolve_host_operation` to accept a per-lifecycle
+  connectivity strategy (multipass / proxmox / azure). Prove behavior-preserving on
+  two-vm (multipass) first; then route proxmox through it (retiring `_build_prelude_tasks`
+  + `_rewrite_ansible`); then azure (**new behavior:** gains the standard provisioning).
+
+- **Phase B2 — Shared loadgen sequence**
+  Extract the `install_k6 → run_k6 → fetch → prometheus → report` (+ ensure/destroy
+  loadgen) sequence into one builder parametrized by the `ConnectivityAdapter`; collapse
+  the three hand-built loadgen blocks.
+
+- **Phase B3 — Final collapse**
+  The three scenarios become thin `(canonical_recipe, ConnectivityAdapter)` instances;
+  remove the per-scenario duplication; one `run()` path.
+
+## 4. Testing Strategy
+
+- **Unit/structural (CI):** recipe `component_ids`/ordering/task-id tests (Phase A must keep
+  them green by construction); adapter resolution unit tests (host/port/key per lifecycle);
+  argv-oracle tests for the unified machinery; shared loadgen-sequence builder tests.
+- **Real-VM validation (NOT in CI — required for Phase B):** because the CI has no e2e VM
+  coverage and Phase B is behavior-changing, each B phase MUST be validated on real VMs:
+  - multipass (`two-vm-loadtest`) — always.
+  - azure / proxmox — when credentials are available; otherwise the behavior change for
+    those lifecycles ships unvalidated and must be flagged in the PR.
+
+## 5. Risks
+
+- **No CI e2e coverage** — the unit tests prove structure (task_ids, argv), not that the
+  real flow works. Behavior changes (azure provisioning, two-vm function registration)
+  can pass all unit tests yet break a real run. Mitigation: §4 real-VM validation gates.
+- **proxmox is the hard lifecycle** — NAT publish + lazy endpoint resolution + its
+  bespoke prelude machinery. Fold it in only after two-vm proves the shared path.
+- **two-vm behavior change** — gaining function registration (REST) is a fix but changes
+  what the flow does; validate the k6 target function is actually registered/served.
+- **Scope creep** — keep helm/namespace → ansible and bash `InstallK6` removal OUT (their
+  own future items); this spec is only the loadtest unification.
+
+## 6. Out of Scope
+- helm/namespace/cleanup → ansible (`helm` module) — separate future item.
+- Removing the deprecated bash `InstallK6` — after B3, separate.
+- The non-loadtest scenarios (`k3s-junit-curl`, `helm-stack`, `cli-stack`) — they already
+  execute recipe-driven via `build_command_tasks`; Phase A dedups their recipes, but they
+  are not part of the loadtest collapse.

--- a/tools/controlplane/src/controlplane_tool/scenario/components/recipes.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/components/recipes.py
@@ -2,22 +2,64 @@ from __future__ import annotations
 
 from workflow_tasks.components.models import ScenarioRecipe
 
+# ── Reusable recipe fragments ────────────────────────────────────────────────
+# Provisioning shared by every managed-VM scenario, up to and including the
+# namespace Helm release (the last step before scenarios diverge).
+BASE_PROVISION: tuple[str, ...] = (
+    "vm.ensure_running",
+    "vm.provision_base",
+    "repo.sync_to_vm",
+    "registry.ensure_container",
+    "images.build_core",
+    "images.build_selected_functions",
+    "k3s.install",
+    "k3s.configure_registry",
+    "namespace.install",
+)
+
+# Deploy nanofaas via Helm (control-plane + function-runtime). Used by every
+# scenario except cli-stack, which installs through the CLI instead.
+HELM_DEPLOY: tuple[str, ...] = (
+    "helm.deploy_control_plane",
+    "helm.deploy_function_runtime",
+)
+
+# Full Helm-based stack prelude (provision + deploy).
+STACK_PRELUDE: tuple[str, ...] = BASE_PROVISION + HELM_DEPLOY
+
+# Shared tail for the loadgen-based loadtest scenarios: build the CLI, register
+# functions, then run the k6 load test from the loadgen VM and tear down.
+LOADTEST_TAIL: tuple[str, ...] = (
+    "cli.build_install_dist",
+    "cli.fn_apply_selected",
+    "loadgen.ensure_running",
+    "loadgen.provision_base",
+    "loadgen.install_k6",
+    "loadgen.run_k6",
+    "metrics.prometheus_snapshot",
+    "loadtest.write_report",
+    "loadgen.down",
+    "vm.down",
+)
+
+# The three loadtest scenarios share one recipe shape (they differ only by
+# lifecycle/connectivity at execution time, not by component list).
+_LOADTEST_COMPONENT_IDS: tuple[str, ...] = STACK_PRELUDE + LOADTEST_TAIL
+
+
+def _loadtest_recipe(name: str) -> ScenarioRecipe:
+    return ScenarioRecipe(
+        name=name,
+        component_ids=_LOADTEST_COMPONENT_IDS,
+        requires_managed_vm=True,
+    )
+
 
 _SCENARIO_RECIPES: dict[str, ScenarioRecipe] = {
     "k3s-junit-curl": ScenarioRecipe(
         name="k3s-junit-curl",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
-            "helm.deploy_control_plane",
-            "helm.deploy_function_runtime",
+        component_ids=STACK_PRELUDE
+        + (
             "tests.run_k3s_curl_checks",
             "tests.run_k8s_junit",
             "cleanup.uninstall_function_runtime",
@@ -29,117 +71,21 @@ _SCENARIO_RECIPES: dict[str, ScenarioRecipe] = {
     ),
     "helm-stack": ScenarioRecipe(
         name="helm-stack",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
-            "helm.deploy_control_plane",
-            "helm.deploy_function_runtime",
+        component_ids=STACK_PRELUDE
+        + (
             "loadtest.install_k6",
             "loadtest.run",
             "experiments.autoscaling",
         ),
         requires_managed_vm=True,
     ),
-    "two-vm-loadtest": ScenarioRecipe(
-        name="two-vm-loadtest",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
-            "helm.deploy_control_plane",
-            "helm.deploy_function_runtime",
-            "cli.build_install_dist",
-            "cli.fn_apply_selected",
-            "loadgen.ensure_running",
-            "loadgen.provision_base",
-            "loadgen.install_k6",
-            "loadgen.run_k6",
-            "metrics.prometheus_snapshot",
-            "loadtest.write_report",
-            "loadgen.down",
-            "vm.down",
-        ),
-        requires_managed_vm=True,
-    ),
-    "azure-vm-loadtest": ScenarioRecipe(
-        name="azure-vm-loadtest",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
-            "helm.deploy_control_plane",
-            "helm.deploy_function_runtime",
-            "cli.build_install_dist",
-            "cli.fn_apply_selected",
-            "loadgen.ensure_running",
-            "loadgen.provision_base",
-            "loadgen.install_k6",
-            "loadgen.run_k6",
-            "metrics.prometheus_snapshot",
-            "loadtest.write_report",
-            "loadgen.down",
-            "vm.down",
-        ),
-        requires_managed_vm=True,
-    ),
-    "proxmox-vm-loadtest": ScenarioRecipe(
-        name="proxmox-vm-loadtest",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
-            "helm.deploy_control_plane",
-            "helm.deploy_function_runtime",
-            "cli.build_install_dist",
-            "cli.fn_apply_selected",
-            "loadgen.ensure_running",
-            "loadgen.provision_base",
-            "loadgen.install_k6",
-            "loadgen.run_k6",
-            "metrics.prometheus_snapshot",
-            "loadtest.write_report",
-            "loadgen.down",
-            "vm.down",
-        ),
-        requires_managed_vm=True,
-    ),
+    "two-vm-loadtest": _loadtest_recipe("two-vm-loadtest"),
+    "azure-vm-loadtest": _loadtest_recipe("azure-vm-loadtest"),
+    "proxmox-vm-loadtest": _loadtest_recipe("proxmox-vm-loadtest"),
     "cli-stack": ScenarioRecipe(
         name="cli-stack",
-        component_ids=(
-            "vm.ensure_running",
-            "vm.provision_base",
-            "repo.sync_to_vm",
-            "registry.ensure_container",
-            "images.build_core",
-            "images.build_selected_functions",
-            "k3s.install",
-            "k3s.configure_registry",
-            "namespace.install",
+        component_ids=BASE_PROVISION
+        + (
             "cli.build_install_dist",
             "cli.platform_install",
             "cli.platform_status",

--- a/tools/controlplane/src/controlplane_tool/scenario/connectivity.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/connectivity.py
@@ -1,0 +1,70 @@
+"""Per-lifecycle connectivity for scenario command execution.
+
+A ConnectivityStrategy supplies the two things that differ between VM lifecycles
+when turning a recipe into honest CommandTasks:
+  - resolve_host_operation: rewrite a host operation's argv/env (ansible inventory,
+    rsync endpoint) to target the VM's SSH endpoint for this lifecycle.
+  - vm_runner: an OrchestratorVmRunner wrapping this lifecycle's orchestrator,
+    used for vm-target operations (helm/docker/gradlew/cli).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from workflow_tasks.components.operations import RemoteCommandOperation
+from workflow_tasks.vm.orchestrator import VmOrchestrator
+from workflow_tasks.vm.runners import OrchestratorVmRunner
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.scenario.command_resolver import CommandResolver
+
+if TYPE_CHECKING:
+    from controlplane_tool.e2e.e2e_runner import E2eRunner
+
+
+def resolve_host_operation(
+    operation: RemoteCommandOperation,
+    *,
+    resolver: CommandResolver,
+    request: E2eRequest,
+    vm: VmOrchestrator,
+    ip_cache: dict[str, str],
+) -> RemoteCommandOperation:
+    """Substitute <multipass-ip:NAME> placeholders in a host operation's argv/env."""
+    argv = resolver._resolve_command(list(operation.argv), request.vm, ip_cache, vm)  # noqa: SLF001
+    env = resolver._resolve_env(dict(operation.env), request.vm, ip_cache, vm)  # noqa: SLF001
+    return RemoteCommandOperation(
+        operation_id=operation.operation_id,
+        summary=operation.summary,
+        argv=tuple(argv),
+        env=env,
+        execution_target=operation.execution_target,
+    )
+
+
+class ConnectivityStrategy(Protocol):
+    def resolve_host_operation(self, operation: RemoteCommandOperation) -> RemoteCommandOperation: ...
+    def vm_runner(self, request: object) -> OrchestratorVmRunner: ...
+
+
+@dataclass
+class MultipassConnectivity:
+    """Current behavior: multipass IP placeholder resolution + multipass orchestrator."""
+
+    runner: "E2eRunner"
+    request: E2eRequest
+    _ip_cache: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+
+    def resolve_host_operation(self, operation: RemoteCommandOperation) -> RemoteCommandOperation:
+        resolver = CommandResolver(host_resolver=self.runner._host_resolver)  # noqa: SLF001
+        return resolve_host_operation(
+            operation,
+            resolver=resolver,
+            request=self.request,
+            vm=self.runner.vm,
+            ip_cache=self._ip_cache,
+        )
+
+    def vm_runner(self, request: object) -> OrchestratorVmRunner:
+        return OrchestratorVmRunner(self.runner.vm, request)

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py
@@ -38,6 +38,11 @@ from workflow_tasks.vm.orchestrator import VmOrchestrator
 from controlplane_tool.infra.vm_lifecycle_adapters import MultipassVmAdapter
 from controlplane_tool.loadtest.loadtest_adapters import OrchestratorVmRunner
 from controlplane_tool.scenario.command_resolver import CommandResolver
+from controlplane_tool.scenario.connectivity import (
+    ConnectivityStrategy,
+    MultipassConnectivity,
+    resolve_host_operation,
+)
 from controlplane_tool.scenario.components.composer import compose_recipe
 from controlplane_tool.scenario.components.environment import resolve_scenario_environment
 from controlplane_tool.scenario.components.executor import ScenarioPlanStep
@@ -118,27 +123,6 @@ def build_setup(runner: "E2eRunner", request: E2eRequest) -> _Setup:
         vm_request=vm_request,
         lifecycle=lifecycle,
         vm_config=vm_config,
-    )
-
-
-def resolve_host_operation(
-    operation: RemoteCommandOperation,
-    *,
-    resolver: CommandResolver,
-    request: E2eRequest,
-    vm: VmOrchestrator,
-    ip_cache: dict[str, str],
-) -> RemoteCommandOperation:
-    """Substitute <multipass-ip:NAME> placeholders in a host operation's argv/env."""
-    # TODO(C-followup): promote CommandResolver.resolve_operation to public.
-    argv = resolver._resolve_command(list(operation.argv), request.vm, ip_cache, vm)  # noqa: SLF001
-    env = resolver._resolve_env(dict(operation.env), request.vm, ip_cache, vm)  # noqa: SLF001
-    return RemoteCommandOperation(
-        operation_id=operation.operation_id,
-        summary=operation.summary,
-        argv=tuple(argv),
-        env=env,
-        execution_target=operation.execution_target,
     )
 
 

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/_workflow_assembly.py
@@ -36,7 +36,6 @@ from workflow_tasks.vm.models import VmConfig
 from controlplane_tool.e2e.e2e_models import E2eRequest
 from workflow_tasks.vm.orchestrator import VmOrchestrator
 from controlplane_tool.infra.vm_lifecycle_adapters import MultipassVmAdapter
-from controlplane_tool.loadtest.loadtest_adapters import OrchestratorVmRunner
 from controlplane_tool.scenario.command_resolver import CommandResolver
 from controlplane_tool.scenario.connectivity import (
     ConnectivityStrategy,
@@ -232,6 +231,7 @@ def build_command_tasks(
     special_handler: SpecialHandler | None = None,
     context_selector: Callable[[object], object] | None = None,
     resolve_host: bool = True,
+    connectivity: ConnectivityStrategy | None = None,
 ) -> list:
     """Route each composed recipe operation to an honest CommandTask.
 
@@ -258,10 +258,11 @@ def build_command_tasks(
     vm_orch = runner.vm
     remote_dir = vm_orch.remote_project_dir(vm_request)
 
+    if connectivity is None:
+        connectivity = MultipassConnectivity(runner=runner, request=request)
+
     host_executor = HostCommandTaskExecutor(runner.shell)
-    vm_executor = VmCommandTaskExecutor(OrchestratorVmRunner(vm_orch, vm_request))
-    resolver = CommandResolver(host_resolver=runner._host_resolver)  # noqa: SLF001
-    ip_cache: dict[str, str] = {}
+    vm_executor = VmCommandTaskExecutor(connectivity.vm_runner(vm_request))
 
     tasks: list = []
     for component in compose_recipe(recipe):
@@ -283,13 +284,7 @@ def build_command_tasks(
                 )
             else:
                 host_op = (
-                    resolve_host_operation(
-                        operation,
-                        resolver=resolver,
-                        request=request,
-                        vm=vm_orch,
-                        ip_cache=ip_cache,
-                    )
+                    connectivity.resolve_host_operation(operation)
                     if resolve_host
                     else operation
                 )

--- a/tools/controlplane/tests/test_connectivity.py
+++ b/tools/controlplane/tests/test_connectivity.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow_tasks.components.operations import RemoteCommandOperation
+from workflow_tasks.shell import RecordingShell
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.e2e.e2e_runner import E2eRunner
+from controlplane_tool.infra.vm.vm_models import VmRequest
+from controlplane_tool.scenario.connectivity import MultipassConnectivity
+
+
+def _runner() -> E2eRunner:
+    return E2eRunner(
+        repo_root=Path("/repo"),
+        shell=RecordingShell(),
+        host_resolver=lambda _request: "10.0.0.9",
+    )
+
+
+def _request() -> E2eRequest:
+    return E2eRequest(
+        scenario="two-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e"),
+    )
+
+
+def test_multipass_connectivity_resolves_host_placeholder() -> None:
+    conn = MultipassConnectivity(runner=_runner(), request=_request())
+    op = RemoteCommandOperation(
+        operation_id="vm.provision_base",
+        summary="Provision",
+        argv=("ansible-playbook", "-i", "<multipass-ip:nanofaas-e2e>,", "provision-base.yml"),
+    )
+
+    resolved = conn.resolve_host_operation(op)
+
+    assert "10.0.0.9," in resolved.argv
+    assert "<multipass-ip:nanofaas-e2e>," not in resolved.argv
+    assert resolved.operation_id == "vm.provision_base"
+
+
+def test_multipass_connectivity_vm_runner_wraps_orchestrator() -> None:
+    runner = _runner()
+    conn = MultipassConnectivity(runner=runner, request=_request())
+
+    vm_runner = conn.vm_runner(VmRequest(lifecycle="multipass", name="nanofaas-e2e"))
+
+    # OrchestratorVmRunner exposes run_vm_command (the VmCommandRunner protocol).
+    assert hasattr(vm_runner, "run_vm_command")

--- a/tools/controlplane/tests/test_recipe_fragments.py
+++ b/tools/controlplane/tests/test_recipe_fragments.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from controlplane_tool.scenario.components.recipes import build_scenario_recipe
+
+# Golden snapshot of every scenario's exact component_ids as of 2026-06-05.
+# This pins current behavior so the fragment refactor (Task 2) stays byte-for-byte identical.
+GOLDEN: dict[str, tuple[str, ...]] = {
+    "k3s-junit-curl": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "tests.run_k3s_curl_checks", "tests.run_k8s_junit",
+        "cleanup.uninstall_function_runtime", "cleanup.uninstall_control_plane",
+        "namespace.uninstall", "vm.down",
+    ),
+    "helm-stack": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "loadtest.install_k6", "loadtest.run", "experiments.autoscaling",
+    ),
+    "two-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "azure-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "proxmox-vm-loadtest": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "helm.deploy_control_plane", "helm.deploy_function_runtime",
+        "cli.build_install_dist", "cli.fn_apply_selected",
+        "loadgen.ensure_running", "loadgen.provision_base", "loadgen.install_k6",
+        "loadgen.run_k6", "metrics.prometheus_snapshot", "loadtest.write_report",
+        "loadgen.down", "vm.down",
+    ),
+    "cli-stack": (
+        "vm.ensure_running", "vm.provision_base", "repo.sync_to_vm",
+        "registry.ensure_container", "images.build_core", "images.build_selected_functions",
+        "k3s.install", "k3s.configure_registry", "namespace.install",
+        "cli.build_install_dist", "cli.platform_install", "cli.platform_status",
+        "cli.fn_apply_selected", "cli.fn_list_selected", "cli.fn_invoke_selected",
+        "cli.fn_enqueue_selected", "cli.fn_delete_selected",
+        "cleanup.uninstall_control_plane", "namespace.uninstall",
+        "cleanup.verify_cli_platform_status_fails", "vm.down",
+    ),
+}
+
+
+def test_recipe_component_ids_match_golden() -> None:
+    for name, expected in GOLDEN.items():
+        assert build_scenario_recipe(name).component_ids == expected, name
+
+
+def test_all_recipes_have_golden_entry() -> None:
+    # Guard against a new scenario being added without updating the golden snapshot.
+    from controlplane_tool.scenario.components.recipes import _SCENARIO_RECIPES
+
+    assert set(_SCENARIO_RECIPES) == set(GOLDEN)

--- a/tools/controlplane/tests/test_recipe_fragments.py
+++ b/tools/controlplane/tests/test_recipe_fragments.py
@@ -74,3 +74,11 @@ def test_all_recipes_have_golden_entry() -> None:
     from controlplane_tool.scenario.components.recipes import _SCENARIO_RECIPES
 
     assert set(_SCENARIO_RECIPES) == set(GOLDEN)
+
+
+def test_loadtest_recipes_are_identical() -> None:
+    # The fragment refactor collapses the three loadtest recipes to one shared definition.
+    two_vm = build_scenario_recipe("two-vm-loadtest").component_ids
+    azure = build_scenario_recipe("azure-vm-loadtest").component_ids
+    proxmox = build_scenario_recipe("proxmox-vm-loadtest").component_ids
+    assert two_vm == azure == proxmox

--- a/tools/controlplane/tests/test_two_vm_stack_prelude_argv.py
+++ b/tools/controlplane/tests/test_two_vm_stack_prelude_argv.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from workflow_tasks.shell import RecordingShell
+
+from controlplane_tool.e2e.e2e_models import E2eRequest
+from controlplane_tool.e2e.e2e_runner import E2eRunner
+from controlplane_tool.infra.vm.vm_models import VmRequest
+from controlplane_tool.scenario.scenarios.two_vm_loadtest import build_two_vm_loadtest_plan
+
+
+def _plan():
+    runner = E2eRunner(
+        repo_root=Path("/repo"),
+        shell=RecordingShell(),
+        host_resolver=lambda _request: "10.0.0.9",
+    )
+    request = E2eRequest(
+        scenario="two-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e"),
+        loadgen_vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e-loadgen"),
+    )
+    return build_two_vm_loadtest_plan(runner, request)
+
+
+def test_two_vm_stack_prelude_argv_is_resolved_and_pinned() -> None:
+    plan = _plan()
+    setup = plan._build_setup()  # noqa: SLF001
+    tasks = plan._build_stack_prelude_tasks(setup, resolve_host=True)  # noqa: SLF001
+
+    by_id = {t.task_id: list(t.spec.argv) for t in tasks if getattr(t, "spec", None) is not None}
+
+    # No unresolved multipass placeholders survive in any host command.
+    for task_id, argv in by_id.items():
+        assert not any("<multipass-ip:" in arg for arg in argv), task_id
+
+    # The provision_base ansible command targets the resolved stack IP.
+    provision = by_id["vm.provision_base"]
+    assert provision[0] == "ansible-playbook"
+    assert "10.0.0.9," in provision
+    assert provision[-1].endswith("provision-base.yml")


### PR DESCRIPTION
Incremental, multi-phase unification of the three VM loadtest scenarios (two-vm / azure / proxmox). This PR accumulates Phase A + B1a; later phases (B1b proxmox, B2 loadgen sequence, B3 collapse) land on the same branch before final merge.

## Phase A — recipe-fragment composition (behavior-preserving)
- `recipes.py` rebuilt from named fragments (`BASE_PROVISION`, `STACK_PRELUDE = BASE_PROVISION + HELM_DEPLOY`, `LOADTEST_TAIL`); the three loadtest recipes collapse to **one shared definition**. `component_ids` are **byte-for-byte identical** to before — no runtime change.
- Golden regression guard (`test_recipe_fragments.py`).

## Phase B1a — ConnectivityStrategy + MultipassConnectivity (behavior-preserving)
- New `controlplane_tool/scenario/connectivity.py`: `ConnectivityStrategy` Protocol (`resolve_host_operation`, `vm_runner`) + `MultipassConnectivity` extracting the current multipass behavior; `resolve_host_operation` moved here and re-exported.
- `build_command_tasks` now takes `connectivity=None`, defaulting to `MultipassConnectivity`, so every existing caller (k3s-junit-curl, helm-stack, cli-stack, two-vm) is unchanged. vm-ops were already lifecycle-agnostic via `OrchestratorVmRunner`; only host-ops (ansible/rsync) route through the strategy.
- Safety net: two-vm stack-prelude argv golden + the existing cli-stack pinned-argv test; behavior-preservation reviewed four ways (identical routing loop, same orchestrator, stateless `CommandResolver` → per-build ip_cache preserved).

## Design docs (on the branch)
- `docs/superpowers/specs/2026-06-05-loadtest-scenario-unification-design.md` — full target architecture + phased roadmap A→B1→B2→B3, with the key finding that the scenarios' divergence is accidental drift (two-vm skips function registration; azure has no provisioning) and only connectivity legitimately differs.
- `docs/superpowers/specs/2026-06-05-connectivity-strategy-b1-design.md` — B1 design.

## Test Plan
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → 1134 passed
- [x] recipe golden + two-vm argv golden + cli-stack pinned-argv green
- [ ] **Real multipass run** of `two-vm-loadtest` end-to-end to validate B1a (no CI e2e coverage; behavior-preserving claim needs a real run). Azure/proxmox deferred/unvalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)