### PR TITLE
fix(ansible): install k6 from GitHub tarball, not the arm64-broken apt repo

### DIFF
--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible_assets/playbooks/install-k6.yml
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible_assets/playbooks/install-k6.yml
@@ -46,38 +46,14 @@
             else ""
           }}
 
-    # ── Ubuntu: install via Grafana apt repository ───────────────────────────
-    - name: Install k6 via apt (Ubuntu)
-      when: ansible_distribution == 'Ubuntu' and k6_installed_version == ""
-      block:
-        - name: Download Grafana GPG key for k6
-          ansible.builtin.get_url:
-            url: https://dl.k6.io/key.gpg
-            dest: /tmp/k6-keyring.gpg
-            mode: "0644"
-
-        - name: Dearmor Grafana GPG key
-          ansible.builtin.command:
-            cmd: gpg --yes --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg /tmp/k6-keyring.gpg
-          args:
-            creates: /usr/share/keyrings/k6-archive-keyring.gpg
-
-        - name: Add k6 apt repository
-          ansible.builtin.copy:
-            dest: /etc/apt/sources.list.d/k6.list
-            content: "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main\n"
-            mode: "0644"
-
-        - name: Install k6 via apt
-          ansible.builtin.apt:
-            name: k6
-            state: present
-            update_cache: true
-            lock_timeout: 120
-
-    # ── Non-Ubuntu: install via GitHub binary download ───────────────────────
-    - name: Install k6 via binary download (non-Ubuntu)
-      when: ansible_distribution != 'Ubuntu' and k6_installed_version == ""
+    # ── Install k6 from the official GitHub release archive ──────────────────
+    # Always use the release tarball (handles amd64 AND arm64). The Grafana apt
+    # repo (dl.k6.io/deb) has no arm64 package, so `apt install k6` fails on
+    # arm64 hosts (e.g. Apple-Silicon multipass) with "No package matching 'k6'".
+    # The binary download is the arch-correct, proven approach — the same one the
+    # legacy bash installer adopted for exactly this reason.
+    - name: Install k6 from the GitHub release archive
+      when: k6_installed_version == ""
       block:
         - name: Fail when k6 is requested on an unsupported architecture
           ansible.builtin.fail:

--- a/tools/workflow-tasks/tests/infra/test_install_k6_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_install_k6_playbook.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from workflow_tasks.infra.ansible import bundled_ansible_root
+
+
+def _playbook_text() -> str:
+    return (bundled_ansible_root() / "playbooks" / "install-k6.yml").read_text(encoding="utf-8")
+
+
+def test_install_k6_uses_github_binary_not_arm64_broken_apt() -> None:
+    """k6 must install from the GitHub release tarball, not the Grafana apt repo.
+
+    The Grafana apt repo (dl.k6.io/deb) ships no arm64 package, so `apt install k6`
+    fails on arm64 hosts (e.g. Apple-Silicon multipass) with "No package matching 'k6'".
+    The release tarball handles amd64 AND arm64 — the arch-correct, proven path.
+    """
+    text = _playbook_text()
+    # No apt-based install (assert on actual task/module usage, not prose mentions).
+    assert "ansible.builtin.apt:" not in text
+    assert "sources.list.d/k6.list" not in text
+    assert "Install k6 via apt" not in text
+    # Installs from the arch-correct GitHub release tarball (amd64 + arm64).
+    assert "github.com/grafana/k6/releases/download" in text
+    assert "linux-{{ k6_arch }}.tar.gz" in text


### PR DESCRIPTION
## Root cause (found via systematic debugging + reproduced on a live VM)
`two-vm-loadtest` failed at **phase 40 "Install k6 on loadgen VM"** during real-multipass validation. The TUI showed only an ansible `[WARNING]: remote_tmp /root/.ansible/tmp ...` — a **benign warning on stderr** that masked the real failure on stdout.

Reproduced the playbook against the live arm64 loadgen VM:
```
TASK [Install k6 via apt]
fatal: FAILED! => {"msg": "No package matching 'k6' is available"}
```
The Grafana apt repo (`dl.k6.io/deb`) ships **no arm64 package**, so `apt install k6` fails on Apple-Silicon/arm64 multipass VMs. `install-k6.yml` took the apt path on Ubuntu; its binary-download path (which handles arm64) was gated to non-Ubuntu only. This is exactly why the legacy bash installer abandoned apt for the curl/tar binary download.

## Fix
Unify `install-k6.yml` on the **GitHub release tarball** for all distributions (handles amd64 **and** arm64). Removes the arch-limited Grafana apt path.

## Verified on real hardware
Re-ran the fixed playbook against the live arm64 loadgen VM:
```
PLAY RECAP: ok=11 changed=4 unreachable=0 failed=0
$ k6 version -> k6 v2.0.0 (... linux/arm64)
```

## Notes
- This is an independent bug in `main` (from the k6-ansible migration, PR #97), surfaced now on first real arm64 validation. It blocks the `two-vm-loadtest` e2e.
- Adds a regression guard (`test_install_k6_playbook.py`) asserting the playbook uses the GitHub tarball, not apt.
- **Follow-up (separate):** `RunPlaybook.run()` surfaces `stderr` over `stdout`, so ansible warnings mask real task failures — worth flipping/merging so future failures are legible.

## Test Plan
- [x] `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests -q` → all pass, coverage 91.6%
- [x] Real arm64 multipass run of `install-k6.yml` → k6 installs and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)