### PR TITLE
fix(ansible): RunPlaybook surfaces stdout+stderr so failures aren't masked

### DIFF
--- a/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/ansible.py
@@ -226,10 +226,14 @@ class RunPlaybook:
             self.playbook, self.request, extra_vars=self.extra_vars
         )
         if result.return_code != 0:
+            # Surface stdout AND stderr: ansible reports task failures on stdout
+            # (PLAY RECAP / "fatal: ... FAILED!") while benign warnings go to stderr,
+            # so stderr alone would mask the real error.
+            detail = "\n".join(
+                part for part in (result.stdout.strip(), result.stderr.strip()) if part
+            )
             raise RuntimeError(
-                result.stderr.strip()
-                or result.stdout.strip()
-                or f"{self.task_id} failed (exit {result.return_code})"
+                detail or f"{self.task_id} failed (exit {result.return_code})"
             )
 
 

--- a/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
+++ b/tools/workflow-tasks/tests/infra/test_ansible_run_playbook.py
@@ -120,3 +120,37 @@ def test_install_k6_task_factory_omits_port_when_none() -> None:
     )
     task.run()
     assert not any("ansible_port=" in arg for arg in shell.commands[0])
+
+
+class _AnsibleLikeFailingShell(ShellBackend):
+    """Mimics ansible: real failure on stdout, benign WARNING on stderr."""
+
+    def run(self, command, *, cwd=None, env=None, dry_run=False) -> ShellExecutionResult:
+        return ShellExecutionResult(
+            command=command,
+            return_code=2,
+            stdout="fatal: [10.0.0.5]: FAILED! => No package matching 'k6' is available",
+            stderr="[WARNING]: Module remote_tmp /root/.ansible/tmp did not exist",
+        )
+
+
+def test_run_playbook_error_surfaces_stdout_failure_not_just_stderr_warning() -> None:
+    adapter = AnsibleAdapter(
+        repo_root=Path("/repo"),
+        shell=_AnsibleLikeFailingShell(),
+        host_resolver=lambda request, dry_run=False: "10.0.0.5",
+    )
+    task = RunPlaybook(
+        task_id="loadgen.install_k6",
+        title="Install k6",
+        adapter=adapter,
+        playbook="install-k6.yml",
+        request=_external_request(),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        task.run()
+
+    message = str(exc.value)
+    # The real ansible failure (on stdout) must be surfaced, not masked by the stderr warning.
+    assert "No package matching 'k6'" in message


### PR DESCRIPTION
## Problem
`RunPlaybook.run()` raised `RuntimeError(result.stderr.strip() or result.stdout.strip() or ...)`. Ansible reports **task failures on stdout** (`fatal: ... FAILED!` / PLAY RECAP) while **benign warnings go to stderr** (e.g. `[WARNING]: Module remote_tmp /root/.ansible/tmp ... mode 0700`). So a warning on stderr **masked the real error** on stdout — exactly what made the k6 arm64 failure (#99) hard to diagnose (the TUI showed only the warning).

## Fix
Combine both streams (stdout first, then stderr) in the error message, so the real failure is always legible. Falls back to `"{task_id} failed (exit N)"` when both are empty.

## Test Plan
- [x] New test: an ansible-like result (failure on stdout, warning on stderr) → the raised message contains the stdout failure, not just the stderr warning.
- [x] Existing `raises_on_nonzero_exit` test still green (stderr-only failure still surfaced).
- [x] `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests -q` → all pass, coverage 92%.

Companion to #99 (k6 arm64 install fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)