### PR TITLE
fix(two-vm-loadtest): upload k6 script to loadgen before RunK6

### DIFF
--- a/tools/controlplane/src/controlplane_tool/e2e/two_vm_loadtest_runner.py
+++ b/tools/controlplane/src/controlplane_tool/e2e/two_vm_loadtest_runner.py
@@ -15,6 +15,7 @@ from controlplane_tool.loadtest.prometheus_snapshots import capture_prometheus_s
 from controlplane_tool.loadtest.report import render_report
 from workflow_tasks.loadtest.remote_k6 import RemoteK6RunConfig, build_k6_command
 from controlplane_tool.scenario.two_vm_loadtest_config import (
+    TwoVmRemotePaths,
     two_vm_control_plane_url,
     two_vm_load_stages,
     two_vm_prometheus_url,
@@ -116,18 +117,14 @@ class TwoVmLoadtestRunner:
         self.host_resolver = host_resolver
         self.runs_root = Path(runs_root) if runs_root is not None else self.paths.runs_dir
 
-    def run_k6(self, request: E2eRequest, *, target_override: str | None = None) -> TwoVmK6Result:
-        if request.vm is None:
-            raise ValueError("two-vm-loadtest requires a stack VM request")
+    def prepare_loadgen(self, request: E2eRequest, remote_paths: TwoVmRemotePaths) -> None:
+        """Create the loadgen run dirs and upload the k6 script (and payload).
+
+        Required before running k6 on the loadgen VM — without it `k6 run` fails
+        immediately because the script file does not exist.
+        """
         if request.loadgen_vm is None:
             raise ValueError("two-vm-loadtest requires a loadgen VM request")
-
-        run_dir = self._create_run_dir()
-        remote_paths = two_vm_remote_paths(
-            self.vm.remote_home(request.loadgen_vm),
-            payload_name=request.k6_payload.name if request.k6_payload is not None else None,
-        )
-
         self._check(
             self.vm.exec_argv(
                 request.loadgen_vm,
@@ -141,7 +138,6 @@ class TwoVmLoadtestRunner:
                 destination=remote_paths.script_path,
             )
         )
-
         if request.k6_payload is not None and remote_paths.payload_path is not None:
             self._check(
                 self.vm.transfer_to(
@@ -150,6 +146,20 @@ class TwoVmLoadtestRunner:
                     destination=remote_paths.payload_path,
                 )
             )
+
+    def run_k6(self, request: E2eRequest, *, target_override: str | None = None) -> TwoVmK6Result:
+        if request.vm is None:
+            raise ValueError("two-vm-loadtest requires a stack VM request")
+        if request.loadgen_vm is None:
+            raise ValueError("two-vm-loadtest requires a loadgen VM request")
+
+        run_dir = self._create_run_dir()
+        remote_paths = two_vm_remote_paths(
+            self.vm.remote_home(request.loadgen_vm),
+            payload_name=request.k6_payload.name if request.k6_payload is not None else None,
+        )
+
+        self.prepare_loadgen(request, remote_paths)
 
         target_function = target_override if target_override is not None else two_vm_target_function(request)
         command = build_k6_command(

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
@@ -177,6 +177,9 @@ class TwoVmLoadtestPlan:
             remote_home,
             payload_name=request.k6_payload.name if request.k6_payload is not None else None,
         )
+        # Create the loadgen run dirs and upload the k6 script before RunK6 — without
+        # this `k6 run` exits immediately ("script.js: No such file") and writes no summary.
+        vm_runner_impl.prepare_loadgen(request, remote_paths)
         run_dir = vm_runner_impl._create_run_dir()  # noqa: SLF001
         control_plane_url = two_vm_control_plane_url(request.vm, host=stack_info.host)
 

--- a/tools/controlplane/tests/test_two_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_plan.py
@@ -49,3 +49,13 @@ def test_two_vm_loadgen_install_uses_runplaybook_not_bash() -> None:
     source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
     assert "install_k6_task(" in source
     assert "InstallK6(" not in source
+
+
+def test_two_vm_run_uploads_k6_script_to_loadgen() -> None:
+    """run() must upload the k6 script before RunK6, else k6 finds no script."""
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import two_vm_loadtest
+
+    source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
+    assert "prepare_loadgen" in source

--- a/tools/controlplane/tests/test_two_vm_loadtest_runner.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_runner.py
@@ -137,3 +137,27 @@ def test_two_vm_loadtest_runner_captures_prometheus_snapshots(
     assert captured["output_dir"] == tmp_path
     assert captured["start"] == started_at
     assert captured["end"] == ended_at
+
+
+def test_prepare_loadgen_creates_dirs_and_uploads_script(tmp_path: Path) -> None:
+    from controlplane_tool.scenario.two_vm_loadtest_config import two_vm_remote_paths
+
+    _write_default_k6_asset(tmp_path)
+    shell = RecordingShell()
+    request = E2eRequest(
+        scenario="two-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e"),
+        loadgen_vm=VmRequest(lifecycle="multipass", name="nanofaas-e2e-loadgen"),
+    )
+    runner = TwoVmLoadtestRunner(
+        repo_root=tmp_path, shell=shell, runs_root=tmp_path / "runs",
+        host_resolver=lambda vm: "10.0.0.2",
+    )
+    remote_paths = two_vm_remote_paths(runner.vm.remote_home(request.loadgen_vm))
+
+    runner.prepare_loadgen(request, remote_paths)
+
+    rendered = [" ".join(command) for command in shell.commands]
+    assert any("mkdir" in c and "-p" in c and "nanofaas-e2e-loadgen" in c for c in rendered)
+    assert any("transfer" in c and "script.js" in c for c in rendered)


### PR DESCRIPTION
## Root cause (found via systematic debugging, reproduced on a live arm64 VM)
`two-vm-loadtest` died at **phase 42 "Fetch k6 results"**:
```
[sftp] cannot open remote file /home/ubuntu/two-vm-loadtest/results/k6-summary.json: No such file
```
The real cause is upstream: **phase 41 "Run k6" took 0.1s** because the k6 script was never on the loadgen VM. The hand-built `TwoVmLoadtestPlan.run()` runs k6 via the `RunK6` task but **never creates the run dirs or uploads the script** — so `k6 run .../scripts/script.js` exits immediately ("No such file"), writes no summary, and the fetch then fails. Confirmed on the live loadgen VM: `/home/ubuntu/two-vm-loadtest` did not exist.

The upload logic already existed in `TwoVmLoadtestRunner.run_k6` (`mkdir -p` + `transfer_to` script/payload), but the scenario's hand-built Workflow bypassed it (a second, divergent k6-run path).

## Fix
Extract `TwoVmLoadtestRunner.prepare_loadgen(request, remote_paths)` (mkdir dirs + upload script + upload payload); `run_k6` now delegates to it (DRY), and `TwoVmLoadtestPlan.run()` calls it before the loadgen Workflow.

## Verified on real hardware (arm64 multipass loadgen)
With the script uploaded + dirs created, k6 actually runs:
```
running (03.1s), 0/2 VUs, 49 complete iterations
-> k6-summary.json (3534 bytes) produced  => fetch now succeeds
```

## Follow-up (separate, noted not fixed)
`RunK6.run()` records `passed = (rc == 0)` but **doesn't raise**, so a failed/instant k6 run still shows a green phase (that's why phase 41 looked green at 0.1s). Same silent-failure class as `RunPlaybook` (#100). Worth surfacing — but changing it would make the e2e hard-fail on any k6 threshold breach, so it needs a deliberate decision.

## Notes
- Independent bug in the two-vm loadgen path (PR #96/#97-era), surfaced on first real-VM run that got past the k6 install (#99). Azure/proxmox loadgen run() paths likely share the same gap (their run() also build RunK6 without an upload) — to verify when validating those lifecycles.

## Test Plan
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` -> 1136 passed
- [x] New: `prepare_loadgen` unit test (mkdir + script upload) + guard that `run()` calls it
- [x] Live arm64 multipass: script upload -> k6 runs -> summary written
- [ ] Full `two-vm-loadtest` e2e re-run to confirm phases 41-46 complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)