### PR TITLE
fix(two-vm-loadtest): register functions on the control plane before k6

### DIFF
--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py
@@ -16,6 +16,7 @@ from workflow_tasks import (
     workflow_step,
     WriteK6Report,
 )
+from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
 from workflow_tasks.components.models import ScenarioRecipe
 from workflow_tasks.loadtest.models import K6Config, K6Stage
 from workflow_tasks.vm.models import VmConfig
@@ -32,6 +33,7 @@ from controlplane_tool.loadtest.loadtest_adapters import (
 )
 from controlplane_tool.scenario.catalog import ScenarioDefinition
 from controlplane_tool.scenario.components.executor import ScenarioPlanStep
+from controlplane_tool.scenario.scenario_helpers import function_image, selected_functions
 from controlplane_tool.scenario.scenarios._workflow_assembly import (
     _Setup,
     build_command_tasks,
@@ -182,6 +184,24 @@ class TwoVmLoadtestPlan:
         vm_runner_impl.prepare_loadgen(request, remote_paths)
         run_dir = vm_runner_impl._create_run_dir()  # noqa: SLF001
         control_plane_url = two_vm_control_plane_url(request.vm, host=stack_info.host)
+
+        # Register the selected functions on the control plane (REST) before k6 runs.
+        # Without this /v1/functions is empty, every invocation 400s, no dispatch
+        # happens, and the required Prometheus metrics (function_dispatch_total) have
+        # no data — failing the Prometheus-snapshot phase.
+        runtime_image_default = f"{setup.context.local_registry}/nanofaas/function-runtime:e2e"
+        RegisterFunctions(
+            task_id="functions.register",
+            title="Register functions",
+            control_plane_url=control_plane_url,
+            specs=[
+                FunctionSpec(
+                    name=fn_key,
+                    image=function_image(fn_key, request.resolved_scenario, runtime_image_default),
+                )
+                for fn_key in selected_functions(request.resolved_scenario)
+            ],
+        ).run()
 
         k6_config = K6Config(
             script_path=Path(remote_paths.script_path),

--- a/tools/controlplane/tests/test_two_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_plan.py
@@ -59,3 +59,14 @@ def test_two_vm_run_uploads_k6_script_to_loadgen() -> None:
 
     source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
     assert "prepare_loadgen" in source
+
+
+def test_two_vm_run_registers_functions_on_control_plane() -> None:
+    """run() must register the selected functions, else k6 invokes a non-existent
+    function (400) and the required Prometheus dispatch metrics have no data."""
+    import inspect
+
+    from controlplane_tool.scenario.scenarios import two_vm_loadtest
+
+    source = inspect.getsource(two_vm_loadtest.TwoVmLoadtestPlan.run)
+    assert "RegisterFunctions" in source


### PR DESCRIPTION
## Root cause (systematic debugging, confirmed on the live stack VM)
After #101 (script upload), `two-vm-loadtest` got past Run k6 / Fetch but died at **phase 43 "Capture Prometheus snapshots"**:
```
required query 'function_dispatch_total' returned no data
```
Probed the live control plane (stack VM): **`GET /v1/functions` → `[]`** (no functions registered), manual invoke → **HTTP 400**, and `function_dispatch_total` / all `function_*` metrics absent. So:
- the hand-built `TwoVmLoadtestPlan.run()` **never registers any function** (the recipe lists `cli.fn_apply_selected` but the run() skips it — the known two-vm drift),
- k6 invokes `word-stats-java` → 400 (function unknown) → no dispatch ever happens,
- the `required=True` Prometheus queries `function_dispatch_total` / `function_success_total` return no data → phase 43 crashes.

## Fix
Mirror proxmox's REST registration: before the loadgen workflow, build `FunctionSpec`s from `selected_functions()` / `function_image()` and POST them via the existing `RegisterFunctions` task against the control-plane URL. Same registration approach proxmox already uses for loadtest scenarios.

This is the same gap class as #101 (missing script upload): the two-vm hand-built `run()` skips recipe steps. Both are patched here pending the loadtest-scenario-unification (which makes all three scenarios run the canonical recipe).

## Test Plan
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → 1137 passed
- [x] Guard test: `run()` calls `RegisterFunctions`
- [x] Live probe confirmed root cause (`/v1/functions` empty; invoke 400; no dispatch metrics)
- [ ] Full `two-vm-loadtest` e2e re-run to confirm phases 43-46 complete

## Notes / likely next
- The k6 http_req_failed threshold may still be crossed if function deployments aren't ready when k6 starts; registering populates the metrics (so phase 43 passes once any dispatch succeeds), but readiness/threshold tuning may be a follow-up.
- `RunK6.run()` still records `passed=False` without raising (silent-failure class, cf. #100) — noted in #101, not changed here.
- azure/proxmox: proxmox already registers via REST; azure's run() likely shares the two-vm gaps (verify when validating azure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)