### PR TITLE
fix(loadtest): make Prometheus snapshot robust to host/VM clock skew (+ caffeinate)

### DIFF
--- a/tools/controlplane/src/controlplane_tool/e2e/e2e_runner.py
+++ b/tools/controlplane/src/controlplane_tool/e2e/e2e_runner.py
@@ -25,6 +25,7 @@ from workflow_tasks.shell import (
     SubprocessShell,
 )
 from workflow_tasks.vm.orchestrator import VmOrchestrator
+from workflow_tasks.infra.host_sleep import prevent_host_sleep
 from controlplane_tool.infra.vm.vm_models import VmRequest
 
 
@@ -349,10 +350,13 @@ class E2eRunner:
         initial_count = self._recorded_command_count()
         plan = self.plan(request)
         self._discard_planning_commands(initial_count)
-        if isinstance(plan, E2ePlan):
-            self.execute(plan, event_listener=event_listener)
-        else:
-            plan.run(event_listener=event_listener)
+        # Keep the host awake for the whole run: idle-sleep drifts the VM clock vs
+        # the host and breaks time-windowed Prometheus queries (macOS only; no-op elsewhere).
+        with prevent_host_sleep():
+            if isinstance(plan, E2ePlan):
+                self.execute(plan, event_listener=event_listener)
+            else:
+                plan.run(event_listener=event_listener)
         return plan
 
     def run_all(
@@ -388,17 +392,19 @@ class E2eRunner:
             ),
             None,
         )
-        succeeded = False
-        try:
-            for plan in plans:
-                plan.run(event_listener=event_listener)
-            succeeded = True
-            return plans
-        finally:
-            final_request = (
-                cast(E2ePlan, plans[-1]).request
-                if plans and isinstance(plans[-1], E2ePlan)
-                else None
-            )
-            if succeeded and shared_vm_request is not None and self._should_teardown(final_request):
-                self.vm.teardown(shared_vm_request)
+        # Keep the host awake for the whole multi-scenario run (macOS; no-op elsewhere).
+        with prevent_host_sleep():
+            succeeded = False
+            try:
+                for plan in plans:
+                    plan.run(event_listener=event_listener)
+                succeeded = True
+                return plans
+            finally:
+                final_request = (
+                    cast(E2ePlan, plans[-1]).request
+                    if plans and isinstance(plans[-1], E2ePlan)
+                    else None
+                )
+                if succeeded and shared_vm_request is not None and self._should_teardown(final_request):
+                    self.vm.teardown(shared_vm_request)

--- a/tools/workflow-tasks/src/workflow_tasks/infra/host_sleep.py
+++ b/tools/workflow-tasks/src/workflow_tasks/infra/host_sleep.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import contextlib
+import subprocess
+import sys
+from collections.abc import Iterator
+
+# macOS `caffeinate` flags: -i prevent idle system sleep, -m prevent disk sleep,
+# -s prevent system sleep while on AC power.
+_CAFFEINATE_CMD = ["caffeinate", "-i", "-m", "-s"]
+
+
+@contextlib.contextmanager
+def prevent_host_sleep() -> Iterator[None]:
+    """Keep the host awake for the duration of the block.
+
+    On macOS this holds a ``caffeinate`` assertion; on other platforms it is a
+    no-op. Long VM-backed scenarios otherwise let the host idle-sleep, which drifts
+    the guest VM clock relative to the host and breaks time-windowed metric queries.
+
+    NOTE: this prevents *idle* sleep only — it does not stop forced sleep (e.g. the
+    laptop lid closing). Pair it with clock-robust metric queries for full coverage.
+    """
+    proc: subprocess.Popen | None = None
+    if sys.platform == "darwin":
+        try:
+            proc = subprocess.Popen(_CAFFEINATE_CMD)
+        except (OSError, ValueError):
+            proc = None
+    try:
+        yield
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()

--- a/tools/workflow-tasks/src/workflow_tasks/loadtest/adapters.py
+++ b/tools/workflow-tasks/src/workflow_tasks/loadtest/adapters.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from workflow_tasks.loadtest.models import TimeWindow
-from workflow_tasks.loadtest.prometheus import query_prometheus_range_series
+from workflow_tasks.loadtest.prometheus import (
+    query_prometheus_range_series,
+    query_prometheus_server_time,
+)
 
 
 class HttpPrometheusClient:
@@ -20,3 +23,7 @@ class HttpPrometheusClient:
         return query_prometheus_range_series(
             self._url, expr, window.start, window.end, step_seconds
         )
+
+    def server_time(self) -> float:
+        """Prometheus's current clock (epoch seconds), for window alignment."""
+        return query_prometheus_server_time(self._url)

--- a/tools/workflow-tasks/src/workflow_tasks/loadtest/prometheus.py
+++ b/tools/workflow-tasks/src/workflow_tasks/loadtest/prometheus.py
@@ -20,6 +20,25 @@ def _prometheus_api_get(
     return data.get("data")
 
 
+def query_prometheus_server_time(base_url: str, timeout_seconds: float = 4.0) -> float:
+    """Return Prometheus's current evaluation time (epoch seconds) via ``time()``.
+
+    Used to align query windows to Prometheus's clock: when the host (which builds
+    the window from wall-clock) and the metrics-source VM (which timestamps the
+    samples) have drifted — e.g. the host slept mid-run — a host-clock window
+    misses the VM-clock samples. ``time()`` reports Prometheus's own clock.
+    """
+    data = _prometheus_api_get(base_url, "/api/v1/query", {"query": "time()"}, timeout_seconds)
+    # Scalar query: data == {"resultType": "scalar", "result": [<eval_ts>, "<value>"]}
+    result = data.get("result") if isinstance(data, dict) else None
+    if isinstance(result, list) and len(result) == 2:
+        try:
+            return float(result[1])
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(f"invalid prometheus time() value: {result!r}") from exc
+    raise RuntimeError(f"unexpected prometheus time() result: {result!r}")
+
+
 def query_prometheus_range_series(
     base_url: str,
     metric_name: str,

--- a/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
+++ b/tools/workflow-tasks/src/workflow_tasks/loadtest/tasks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -138,8 +138,36 @@ class CapturePrometheusSnapshot:
             return self.window()
         return self.window
 
+    # Skew below this (seconds) is treated as no drift; margin widens the shifted
+    # window to absorb the Prometheus scrape interval.
+    _CLOCK_SKEW_THRESHOLD_S = 5.0
+    _WINDOW_MARGIN_S = 30.0
+
+    def _align_window(self, window: TimeWindow) -> TimeWindow:
+        """Shift the host-clock window into Prometheus's clock domain.
+
+        The window start/end come from the k6 run on the host clock, but Prometheus
+        timestamps samples with the metrics-source VM clock. When those clocks drift
+        (e.g. the host slept mid-run), a host-clock window misses the VM-clock
+        samples. Anchor the window to Prometheus's own clock so the snapshot is
+        robust to that skew. Clients without ``server_time`` (e.g. test fakes) are
+        left unshifted.
+        """
+        server_time = getattr(self.client, "server_time", None)
+        if server_time is None:
+            return window
+        try:
+            offset = float(server_time()) - datetime.now(timezone.utc).timestamp()
+        except (RuntimeError, OSError, ValueError, TypeError):
+            return window
+        if abs(offset) < self._CLOCK_SKEW_THRESHOLD_S:
+            return window
+        shift = timedelta(seconds=offset)
+        margin = timedelta(seconds=self._WINDOW_MARGIN_S)
+        return TimeWindow(start=window.start + shift - margin, end=window.end + shift + margin)
+
     def run(self) -> Path:
-        window = self._resolve_window()
+        window = self._align_window(self._resolve_window())
         metrics_dir = self.output_dir / "metrics"
         metrics_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tools/workflow-tasks/tests/infra/test_host_sleep.py
+++ b/tools/workflow-tasks/tests/infra/test_host_sleep.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import workflow_tasks.infra.host_sleep as host_sleep
+from workflow_tasks.infra.host_sleep import prevent_host_sleep
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.terminated = False
+        self._running = True
+
+    def poll(self):
+        return None if self._running else 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._running = False
+
+    def wait(self, timeout=None) -> int:
+        return 0
+
+
+def test_prevent_host_sleep_caffeinates_on_macos(monkeypatch) -> None:
+    monkeypatch.setattr(host_sleep.sys, "platform", "darwin")
+    calls: list[list[str]] = []
+    proc = _FakeProc()
+
+    def fake_popen(cmd):
+        calls.append(cmd)
+        return proc
+
+    monkeypatch.setattr(host_sleep.subprocess, "Popen", fake_popen)
+
+    with prevent_host_sleep():
+        assert calls == [host_sleep._CAFFEINATE_CMD]
+        assert proc.terminated is False
+
+    assert proc.terminated is True  # released on exit
+
+
+def test_prevent_host_sleep_is_noop_off_macos(monkeypatch) -> None:
+    monkeypatch.setattr(host_sleep.sys, "platform", "linux")
+
+    def boom(cmd):
+        raise AssertionError("caffeinate must not run off macOS")
+
+    monkeypatch.setattr(host_sleep.subprocess, "Popen", boom)
+
+    with prevent_host_sleep():
+        pass  # no exception => no Popen attempted

--- a/tools/workflow-tasks/tests/loadtest/test_loadtest_tasks.py
+++ b/tools/workflow-tasks/tests/loadtest/test_loadtest_tasks.py
@@ -427,3 +427,51 @@ def test_write_k6_report_works_without_prometheus_snapshot(tmp_path: Path) -> No
     )
     report_path = task.run()
     assert report_path.exists()
+
+
+class _ClockOffsetPrometheusClient:
+    """Prometheus client whose clock is offset from the host (simulates VM drift)."""
+
+    def __init__(self, offset_seconds: float) -> None:
+        self._offset = offset_seconds
+        self.calls: list[tuple[str, TimeWindow, int]] = []
+
+    def server_time(self) -> float:
+        return datetime.now(timezone.utc).timestamp() + self._offset
+
+    def query_range(self, expr: str, window: TimeWindow, step_seconds: int = 5) -> list[dict]:
+        self.calls.append((expr, window, step_seconds))
+        return [{"timestamp": "t", "value": 1.0}]
+
+
+def test_capture_prometheus_snapshot_shifts_window_to_prometheus_clock(tmp_path: Path) -> None:
+    offset = -1500.0  # Prometheus/VM clock 25 min behind the host (host slept mid-run)
+    client = _ClockOffsetPrometheusClient(offset)
+    window = _make_window()
+    task = CapturePrometheusSnapshot(
+        task_id="metrics.snapshot",
+        title="Capture snapshots",
+        client=client,
+        queries=(PrometheusQuery(name="dispatch", expr="function_dispatch_total", required=True),),
+        window=window,
+        output_dir=tmp_path,
+    )
+    task.run()  # must NOT raise: window is aligned so the required query finds data
+    queried = client.calls[0][1]
+    assert abs(queried.start.timestamp() - (window.start.timestamp() + offset)) <= 60
+    assert abs(queried.end.timestamp() - (window.end.timestamp() + offset)) <= 60
+
+
+def test_capture_prometheus_snapshot_keeps_window_without_server_time(tmp_path: Path) -> None:
+    client = _RecordingPrometheusClient()  # no server_time() -> unshifted (back-compat)
+    window = _make_window()
+    task = CapturePrometheusSnapshot(
+        task_id="metrics.snapshot",
+        title="Capture snapshots",
+        client=client,
+        queries=(PrometheusQuery(name="req", expr="http_requests_total"),),
+        window=window,
+        output_dir=tmp_path,
+    )
+    task.run()
+    assert client.calls[0][1] == window

--- a/tools/workflow-tasks/tests/loadtest/test_prometheus.py
+++ b/tools/workflow-tasks/tests/loadtest/test_prometheus.py
@@ -48,3 +48,14 @@ def test_query_range_series_returns_parsed_points() -> None:
     assert isinstance(result, list)
     assert len(result) == 2
     assert result[0]["value"] == 42.0
+
+
+def test_query_prometheus_server_time_parses_time_scalar(monkeypatch) -> None:
+    from workflow_tasks.loadtest import prometheus
+
+    monkeypatch.setattr(
+        prometheus,
+        "_prometheus_api_get",
+        lambda *a, **k: {"resultType": "scalar", "result": [1780728785.1, "1780728785.1"]},
+    )
+    assert prometheus.query_prometheus_server_time("http://prom") == 1780728785.1


### PR DESCRIPTION
## Root cause (systematic debugging, confirmed on live VMs)
`two-vm-loadtest` reached phase 43 "Capture Prometheus snapshots" and failed:
```
required query 'function_dispatch_total' returned no data
```
But the metric **had data** — probing the live stack VM showed `function_dispatch_total` ramping 27→387 (263 successful invocations). The failure was a **clock-domain mismatch**:
- `CapturePrometheusSnapshot` builds its query window from the **host** wall-clock (k6 `started_at`/`ended_at`),
- Prometheus timestamps samples with the **metrics-source VM** clock,
- the macOS host slept mid-run, drifting the VM clock **~24 min** behind the host,
- so the narrow (~45s) host-clock window missed the VM-clock samples → "no data".

(Confirmed: a wide 30-min host window *did* catch the data — only the narrow run window, shifted by the skew, missed it.)

## Fix — two layers (defense in depth)
**(B) Clock-robust snapshot** — `PrometheusClient.server_time()` (via Prometheus `time()`); `CapturePrometheusSnapshot` shifts its window by `(prom_now - host_now)` (with margin) when the skew is significant, so the window lands in Prometheus's clock domain. Clients without `server_time` (test fakes) are unshifted. → immune to *any* clock skew.

**(caffeinate) Prevent host idle-sleep** — `prevent_host_sleep()` (macOS `caffeinate`, no-op elsewhere) wraps `E2eRunner.run()`/`run_all()` so long VM-backed runs don't let the Mac idle-sleep in the first place. Does not stop *forced* sleep (lid close) — hence B is the fundamental fix.

## Notes
- The platform itself works end-to-end now (263 successful function invocations); this was purely a metrics-snapshot windowing bug surfaced by host sleep during multi-day debugging.
- Both layers are additive; B is the reliable one.

## Test Plan
- [x] `uv run --project tools/workflow-tasks pytest tools/workflow-tasks/tests -q` → all pass, 91% coverage (new: window-shift, no-server_time back-compat, `time()` parse, caffeinate on/off macOS)
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → 1137 passed (E2eRunner.run/run_all wrap intact)
- [x] Root cause confirmed live (24min skew; dispatch metric present)
- [ ] Full `two-vm-loadtest` e2e re-run to confirm phases 43-46 complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)