### PR TITLE
feat(tui): prompt 'Cleanup VM at end?' (default yes) for all VM scenarios

### DIFF
--- a/tools/controlplane/src/controlplane_tool/tui/app.py
+++ b/tools/controlplane/src/controlplane_tool/tui/app.py
@@ -55,6 +55,22 @@ from controlplane_tool.tui.workflow_controller import TuiWorkflowController
 
 _STYLE = to_questionary_style(DEFAULT_THEME)
 
+
+def _ask_cleanup_vm() -> bool:
+    """Ask whether to destroy the VM(s) at the end of the run (default: yes).
+
+    Used uniformly by every VM-backed scenario so cleanup is opt-out, not
+    hardcoded per scenario.
+    """
+    return _ask(
+        lambda: questionary.confirm(
+            "Cleanup VM at end?",
+            default=True,
+            style=_STYLE,
+        ).ask()
+    )
+
+
 # ── Main application ─────────────────────────────────────────────────────────
 
 
@@ -981,6 +997,7 @@ class NanofaasTUI:
             from controlplane_tool.cli.e2e_commands import _resolve_run_request
             from controlplane_tool.e2e.e2e_runner import E2eRunner
 
+            cleanup_vm = _ask_cleanup_vm()
             request = _resolve_run_request(
                 scenario=scenario,
                 runtime="java",
@@ -992,7 +1009,7 @@ class NanofaasTUI:
                 cpus=4,
                 memory="8G" if scenario == "two-vm-loadtest" else "12G",
                 disk="30G",
-                cleanup_vm=False,
+                cleanup_vm=cleanup_vm,
                 namespace=None,
                 local_registry=None,
                 function_preset=None,
@@ -1071,6 +1088,7 @@ class NanofaasTUI:
             if not confirmed:
                 return
 
+            cleanup_vm = _ask_cleanup_vm()
             request = _resolve_run_request(
                 scenario="azure-vm-loadtest",
                 runtime="java",
@@ -1082,7 +1100,7 @@ class NanofaasTUI:
                 cpus=4,
                 memory="12G",
                 disk="30G",
-                cleanup_vm=False,
+                cleanup_vm=cleanup_vm,
                 namespace=None,
                 local_registry=None,
                 function_preset=None,
@@ -1176,6 +1194,7 @@ class NanofaasTUI:
             if not confirmed:
                 return
 
+            cleanup_vm = _ask_cleanup_vm()
             request = _resolve_run_request(
                 scenario="proxmox-vm-loadtest",
                 runtime="java",
@@ -1187,7 +1206,7 @@ class NanofaasTUI:
                 cpus=cfg.cpus,
                 memory=cfg.memory,
                 disk=cfg.disk,
-                cleanup_vm=True,
+                cleanup_vm=cleanup_vm,
                 namespace=None,
                 local_registry=None,
                 function_preset=None,
@@ -1256,13 +1275,7 @@ class NanofaasTUI:
                     style=_STYLE,
                 ).ask()
             )
-            cleanup_vm = _ask(
-                lambda: questionary.confirm(
-                    "Cleanup VM at end?",
-                    default=True,
-                    style=_STYLE,
-                ).ask()
-            )
+            cleanup_vm = _ask_cleanup_vm()
             selection = _prompt_function_selection(K3S_SELECTION_TARGET)
 
             dry_run = _ask(

--- a/tools/controlplane/tests/test_tui_choices.py
+++ b/tools/controlplane/tests/test_tui_choices.py
@@ -2230,6 +2230,7 @@ def test_tui_helm_stack_scenario_shows_shared_execution_phases(monkeypatch) -> N
     import controlplane_tool.tui.app as tui_app
     import controlplane_tool.e2e.e2e_runner as e2e_runner
 
+    monkeypatch.setattr(tui_app, "_ask", lambda prompt_fn: True)
     called: dict[str, object] = {}
 
     class _FakePlan:
@@ -2310,6 +2311,7 @@ def test_tui_helm_stack_scenario_does_not_add_wrapper_steps_to_dashboard(monkeyp
     import controlplane_tool.tui.app as tui_app
     import controlplane_tool.e2e.e2e_runner as e2e_runner
 
+    monkeypatch.setattr(tui_app, "_ask", lambda prompt_fn: True)
     captured: dict[str, object] = {}
 
     class _FakePlan:
@@ -2571,17 +2573,7 @@ def test_tui_helm_stack_scenario_uses_demo_loadtest_defaults(monkeypatch) -> Non
 
     called: dict[str, object] = {}
 
-    monkeypatch.setattr(
-        tui_app,
-        "_ask",
-        lambda prompt_fn: {
-            "Scenario:": "helm-stack",
-            "VM Name:": "nanofaas-e2e",
-            "Control-plane runtime:": "java",
-            "Cleanup VM at end?": False,
-            "Dry-run? (show plan without executing)": True,
-        }[str(prompt_fn().message)],
-    )
+    monkeypatch.setattr(tui_app, "_ask", lambda prompt_fn: True)
 
     def fake_build_scenario_flow(scenario, **kwargs):  # noqa: ANN001
         called["scenario"] = scenario
@@ -2602,6 +2594,7 @@ def test_tui_two_vm_loadtest_uses_two_vm_request_defaults(monkeypatch) -> None:
     import controlplane_tool.tui.app as tui_app
     import controlplane_tool.e2e.e2e_runner as e2e_runner
 
+    monkeypatch.setattr(tui_app, "_ask", lambda prompt_fn: True)
     called: dict[str, object] = {}
 
     class _FakePlan:
@@ -2641,6 +2634,8 @@ def test_tui_two_vm_loadtest_uses_two_vm_request_defaults(monkeypatch) -> None:
     assert request.vm.memory == "8G"
     assert request.loadgen_vm is not None
     assert request.loadgen_vm.name == "nanofaas-e2e-loadgen"
+    # The "Cleanup VM at end?" prompt (mocked yes here) drives cleanup_vm — not a hardcode.
+    assert request.cleanup_vm is True
 
 
 def test_tui_proxmox_vm_loadtest_keeps_cleanup_phases_enabled(monkeypatch) -> None:


### PR DESCRIPTION
## Why
Running `two-vm-loadtest` from the TUI never destroyed its VMs (phases 45/46 "Destroy" skipped), surprising the user who expected cleanup by default. Root cause: `_run_vm_e2e_scenario` **hardcoded** `cleanup_vm` per scenario — `False` for two-vm-loadtest / helm-stack (since 2026-04-10, commit a1e719b8) and azure, `True` for proxmox, while only k3s-junit-curl actually prompted. Inconsistent and surprising.

## Change
Add a shared `_ask_cleanup_vm()` helper (`questionary.confirm("Cleanup VM at end?", default=True)`) and use it uniformly in **every** VM-backed branch (k3s-junit-curl, helm-stack, two-vm-loadtest, azure-vm-loadtest, proxmox-vm-loadtest). Cleanup is now a consistent opt-out prompt (default yes) instead of a per-scenario hardcode. k3s keeps prompting at the same point (just via the helper), so its prompt sequence is unchanged.

## Test Plan
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → 1137 passed
- [x] Updated the helm-stack/two-vm TUI tests to mock the new cleanup prompt; added an assertion that the prompt result drives `request.cleanup_vm`
- [x] k3s TUI tests unchanged (prompt position preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)