### PR TITLE
Phase B3b: fold proxmox into the unified flow (characterization-first)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-loadtest-b3b-proxmox-fold.md
+++ b/docs/superpowers/plans/2026-06-07-loadtest-b3b-proxmox-fold.md
@@ -1,0 +1,237 @@
+# Phase B3b — Fold proxmox into the unified flow (characterization-first) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route the proxmox loadtest scenario through the unified `run_loadtest_flow` driver (from B3a), retiring proxmox's bespoke `_run_prelude_workflow`/`_run_tail_tasks`/`_tail_tasks`/`_skeleton`/`_ActionTask` machinery — WITHOUT changing observable behavior, guarded by characterization tests written FIRST (proxmox cannot be validated on real hardware).
+
+**Architecture:** Phase 1 writes characterization tests that pin proxmox's CURRENT behavior the argv golden doesn't cover: the full `ScenarioStepEvent` emission sequence, failure-cleanup (VM teardown on exception), and in-prelude registration + port-publish. Phase 2 generalizes the driver/adapter so they can reproduce that behavior (adapter-supplied recipe + special_handler + context_selector + register strategy + extra_steps + an event-emission strategy + a failure-cleanup hook + `extra_step_titles`), keeping two-vm byte-identical. Phase 3 adds `ProxmoxLoadtestAdapter` and routes proxmox through the driver. Phase 4 verifies + sweeps the retired machinery.
+
+**Tech Stack:** Python 3.12, `uv`, pytest. `controlplane_tool.scenario.loadtest_flow` / `loadtest_adapter` (from B3a), `ProxmoxConnectivity` (from B1b), proxmox test fakes.
+
+**Decisions (locked):**
+- User chose **characterization-tests-first** for this unvalidatable fold (brainstorm risk question, 2026-06-07).
+- Two-vm (multipass, B3a) must stay **byte-identical** — its `argv`/`task_ids`/`phase_titles` goldens AND its current event behavior (driver ignores `event_listener`; progress flows via the global `WorkflowEvent`/`workflow_step` bus) must not change. The new ScenarioStepEvent emission is **opt-in per adapter** (proxmox opts in; multipass does not).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-loadtest-b3-final-collapse-design.md`.
+
+**Validation gate:** proxmox CANNOT be validated on real hardware (no Proxmox). The characterization tests + argv golden are the guarantee. The PR MUST flag proxmox as argv+characterization-guarded but real-VM-unvalidated. (multipass two-vm must still pass its existing real-VM gate — unaffected here.)
+
+---
+
+## Reference: proxmox's behaviors to preserve (the contract)
+
+From `tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py`:
+
+1. **Prelude recipe differs** — `_PROXMOX_LOADTEST_PRELUDE_COMPONENTS` includes `vm.ensure_running` (run separately as task_id `vm.ensure_running`), and `cli.build_install_dist` + `cli.fn_apply_selected`. Registration happens IN the prelude: `special_handler` substitutes `cli.fn_apply_selected` → a `CallableTask("functions.register", ...)` that publishes the control-plane NAT port (`publish_port(service="CONTROL_PLANE_HTTP")`) and calls `RegisterFunctions(...).run()`. `context_selector` gives `cli.*` components a `CliComponentContext`. The prelude uses `ProxmoxConnectivity` (B1b) for the host-op rewrites.
+2. **Event emission** — `run(event_listener)` emits `ScenarioStepEvent(step_index, total_steps, step, status in {running,success,failed}, error)`: prelude tasks via `_run_prelude_workflow` (indices 1..len(prelude)); tail tasks via `_run_tail_tasks` (offset = len(prelude)). `total_steps = len(self.task_ids)`. On task failure, emits `failed` then raises `RuntimeError("Scenario '...' failed at step '<title>': <exc>")`.
+3. **Failure-cleanup** — on ANY prelude/tail exception, `_cleanup_proxmox_requests` tears down loadgen + stack VMs (if `cleanup_vm`); wraps cleanup errors into the raised message.
+4. **Tail (lazy)** — ensure_stack→ensure_loadgen→publish_ports(prometheus)→install_k6→run_k6→fetch→prometheus→report, with NAT endpoints resolved lazily; cleanup destroys loadgen then stack. (B2 already routed the body construction through `build_loadgen_body_tasks`.)
+5. **task_ids ordering** (`test_proxmox_vm_loadtest_plan_task_ids_include_platform_prefix`): `functions.register` < `vm.stack.publish_ports` < `loadgen.install_k6`. Note proxmox's static plan DOES include `vm.stack.publish_ports` (a `_SkeletonStep`) — so the adapter's `extra_step_ids(BEFORE_LOADGEN)` returns `["vm.stack.publish_ports"]` and `extra_step_titles` returns `["Publish Proxmox NAT ports"]`.
+
+Existing tests already partially characterize this (`test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails`, `test_proxmox_vm_loadtest_tail_events_start_after_prelude`, the task_ids ordering test, `test_proxmox_prelude_argv.py`). Phase 1 EXTENDS them into a complete contract.
+
+---
+
+## File Structure
+
+- **Modify** `tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py` — add the comprehensive characterization tests (Phase 1).
+- **Modify** `tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py` — generalize the driver: optional ScenarioStepEvent emission strategy, failure-cleanup hook, adapter-supplied recipe/special_handler/context_selector + register strategy, `extra_step_titles` in `phase_titles`.
+- **Modify** `tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py` — add the new optional adapter members (with no-op defaults preserving multipass), and `ProxmoxLoadtestAdapter`.
+- **Modify** `tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py` — route through the driver; retire the bespoke machinery.
+
+---
+
+## Phase 1 — Characterization (NO production changes)
+
+### Task 1: Pin proxmox's full ScenarioStepEvent sequence (success path)
+
+**Files:**
+- Test: `tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py`
+
+Extend the existing `test_proxmox_vm_loadtest_tail_events_start_after_prelude` fixture pattern into a test that captures the COMPLETE event sequence and asserts the exact ordered list of `(step_index, total_steps, step_id, status)` for a successful run.
+
+- [ ] **Step 1: Write the characterization test**
+
+Add `test_proxmox_event_sequence_is_pinned`. Reuse the existing fakes (`FakeProxmoxVmOrchestrator`, `FakeTwoVmLoadtestRunner`, `FakeEnsureVmRunning`, `FakeTask`, `fake_build_prelude_tasks` returning a single `prelude.noop` CallableTask, `fake_build_loadgen_body_tasks`) — copy them from `test_proxmox_vm_loadtest_tail_events_start_after_prelude` (lines ~217-320). Capture events and assert the full tuple list:
+
+```python
+def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
+    # ... identical fixture setup to test_proxmox_vm_loadtest_tail_events_start_after_prelude,
+    # with cleanup_vm=False ...
+    events = []
+    plan.run(event_listener=events.append)
+
+    seq = [(e.step_index, e.step.step_id, e.status) for e in events]
+    # total_steps is constant across all events:
+    assert {e.total_steps for e in events} == {len(plan.task_ids)}
+    # Each step emits running then success, in order; prelude (index 1) then tail (offset=1).
+    assert seq == [
+        (1, "prelude.noop", "running"), (1, "prelude.noop", "success"),
+        (2, "vm.stack.ensure_running", "running"), (2, "vm.stack.ensure_running", "success"),
+        (3, "vm.loadgen.ensure_running", "running"), (3, "vm.loadgen.ensure_running", "success"),
+        (4, "vm.stack.publish_ports", "running"), (4, "vm.stack.publish_ports", "success"),
+        (5, "loadgen.install_k6", "running"), (5, "loadgen.install_k6", "success"),
+        (6, "loadgen.run_k6", "running"), (6, "loadgen.run_k6", "success"),
+        (7, "loadgen.fetch_results", "running"), (7, "loadgen.fetch_results", "success"),
+        (8, "metrics.prometheus_snapshot", "running"), (8, "metrics.prometheus_snapshot", "success"),
+        (9, "loadtest.write_report", "running"), (9, "loadtest.write_report", "success"),
+    ]
+```
+
+IMPORTANT: This asserts the CURRENT behavior. Run it against the UNCHANGED proxmox code first — if the real emitted sequence differs (e.g. different step_ids/indices because the synthetic prelude is one task, or publish_ports index differs), ADJUST the expected list to match what the CURRENT code emits (this is characterization — pin reality, not the plan author's guess). Document the exact captured sequence in the test.
+
+- [ ] **Step 2: Run against unchanged code; confirm it PASSES (pins reality)**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py::test_proxmox_event_sequence_is_pinned -q`
+Expected: PASS (it characterizes current behavior). If it fails, the expected list is wrong — fix the EXPECTED list to match the actual emission, not the code.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+git commit -m "test(proxmox): characterize the full ScenarioStepEvent sequence"
+```
+
+### Task 2: Pin failure-cleanup on BOTH prelude and tail failure
+
+**Files:**
+- Test: `tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py`
+
+`test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails` already pins prelude-failure cleanup. Add a tail-failure variant + assert the wrapped error message format.
+
+- [ ] **Step 1: Write the test**
+
+Add `test_proxmox_tail_failure_tears_down_vms`: reuse the fixture, but make a tail task raise (e.g. monkeypatch `fake_build_loadgen_body_tasks` so the `loadgen.run_k6` FakeTask's `.run()` raises `RuntimeError("boom")`), set `cleanup_vm=True`, record `teardown` calls on the fake orchestrator, and assert: (a) `run()` raises, (b) teardown was called for BOTH loadgen and stack requests, (c) the raised message matches the `Scenario '...' failed at step '...'` format (read the current `_run_tail_tasks`/`_run_prelude_workflow` to get the exact format and pin it).
+
+```python
+def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
+    # ... fixture as above but cleanup_vm=True; FakeProxmoxVmOrchestrator records teardown calls ...
+    # make the run_k6 body task raise
+    ...
+    with pytest.raises(RuntimeError) as exc:
+        plan.run(event_listener=lambda e: None)
+    assert "failed at step" in str(exc.value)
+    assert teardown_calls == ["proxmox-loadgen", "proxmox-stack"]  # order per _cleanup_proxmox_requests
+```
+
+Read the current code to get exact teardown order and message; pin what the code actually does.
+
+- [ ] **Step 2: Run against unchanged code; confirm PASS**
+
+Run: `uv run --project tools/controlplane pytest tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py -q -k "tail_failure or cleans_up"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+git commit -m "test(proxmox): characterize failure-cleanup on tail failure"
+```
+
+---
+
+## Phase 2 — Generalize the driver/adapter (two-vm stays byte-identical)
+
+### Task 3: Adapter capabilities for events, failure-cleanup, recipe/registration (no-op defaults)
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py`
+- Test: `tools/controlplane/tests/test_loadtest_adapter.py`
+
+Add OPTIONAL members to the `LoadtestConnectivityAdapter` Protocol and implement no-op defaults on `MultipassLoadtestAdapter` so two-vm behavior is unchanged:
+- `prelude_recipe(self)` — the recipe for the provision prelude. Multipass returns the `two-vm-loadtest-stack` recipe it builds today (move the recipe construction here from `loadtest_flow`/two-vm). Proxmox returns its filtered `proxmox-vm-loadtest` recipe.
+- `prelude_special_handler(self, ctx)` → `SpecialHandler | None` (multipass: `None`).
+- `prelude_context_selector(self, ctx)` → `Callable | None` (multipass: `None`).
+- `register_functions(self, ctx) -> None` — multipass: the inline RegisterFunctions (moved from the driver's `_register_functions`); proxmox: **no-op** (registration is in the prelude). This replaces the driver's hardcoded register call.
+- `emits_step_events(self) -> bool` — multipass `False` (keeps ignoring `event_listener`); proxmox `True`.
+- `cleanup_on_failure(self, error: Exception) -> list[str]` — multipass: `[]` (no-op); proxmox: teardown VMs, return error strings.
+- `extra_step_titles(self, phase) -> list[str]` — the B3a follow-up; multipass `[]`.
+- `ensure_stack_task_id(self)` / `ensure_stack_title(self)` — multipass: `("vm.stack.ensure_running", "Ensure stack VM running")`. Proxmox runs the stack ensure as task_id `vm.ensure_running` silently in the prelude phase but the DISPLAYED/event id is `vm.stack.ensure_running` — capture proxmox's exact naming here (verify against the characterization test from Task 1).
+
+- [ ] **Step 1: Write failing tests** asserting `MultipassLoadtestAdapter` no-op defaults: `emits_step_events() is False`, `cleanup_on_failure(Exception()) == []`, `prelude_special_handler(ctx) is None`, `prelude_context_selector(ctx) is None`, `extra_step_titles(phase) == []`, and `register_functions` is callable. (Construct the adapter with `SimpleNamespace` fakes as in the existing adapter tests.)
+
+- [ ] **Step 2: Run → fail.** `uv run --project tools/controlplane pytest tools/controlplane/tests/test_loadtest_adapter.py -q`
+
+- [ ] **Step 3: Implement** the Protocol additions + `MultipassLoadtestAdapter` no-op defaults. Move the `two-vm-loadtest-stack` `ScenarioRecipe` construction into `MultipassLoadtestAdapter.prelude_recipe()`, and move the inline-RegisterFunctions logic (currently the driver's `_register_functions`, which reads `setup.context.local_registry` + `selected_functions` + `function_image`) into `MultipassLoadtestAdapter.register_functions(ctx)` — it needs `setup`/`request`; store them on the adapter (the adapter already holds `runner`/`request`; pass `setup` via the driver or have the adapter rebuild it). KEEP the exact behavior. Verify `function_image`/`selected_functions` import paths.
+
+- [ ] **Step 4: Run → pass.** ruff clean.
+
+- [ ] **Step 5: Commit** `feat(loadtest): adapter capabilities for events/cleanup/recipe/register (no-op multipass defaults)`.
+
+### Task 4: Generalize `run_loadtest_flow` + static plan to use the adapter capabilities
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py`
+- Test: `tools/controlplane/tests/test_loadtest_flow.py`, and the two-vm goldens (must stay green)
+
+Rework the driver so it:
+- Builds the prelude from `adapter.prelude_recipe()` with `adapter.prelude_special_handler(ctx)` + `adapter.prelude_context_selector(ctx)` passed to `build_command_tasks`.
+- Calls `adapter.register_functions(ctx)` instead of the hardcoded `_register_functions` (multipass: inline REST; proxmox: no-op).
+- Emits `ScenarioStepEvent`s when `adapter.emits_step_events()` is True, wrapping each executed task with running/success/failed + sequential `step_index` and `total_steps = len(task_ids)`, matching the format pinned in Task 1/2. When False (multipass), uses the existing native `workflow_step` path unchanged (two-vm byte-identical).
+- Wraps the whole flow in try/except calling `adapter.cleanup_on_failure(exc)` and re-raising with the wrapped message (matching Task 2's pinned format) — a no-op for multipass (`cleanup_on_failure` returns `[]`, so the wrapper just re-raises the original).
+- `loadtest_flow_phase_titles` injects `adapter.extra_step_titles(phase)` at the same points `loadtest_flow_task_ids` injects `extra_step_ids` (fixes the B3a divergence).
+
+- [ ] **Step 1: Write tests** — (a) a driver test with a fake adapter where `emits_step_events()` is True asserting the running/success/index/total_steps wrapping; (b) a driver test where `cleanup_on_failure` is invoked on a raised task and the message is wrapped; (c) extend the multipass static-plan test to confirm `extra_step_titles` injection aligns titles with ids when the fake adapter returns a publish step.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** the generalization. CRITICAL: when `emits_step_events()` is False, the code path must be EXACTLY B3a's (native `workflow_step`, `event_listener` unused) so two-vm stays byte-identical. Structure the event emission as a wrapper applied only when the adapter opts in.
+
+- [ ] **Step 4: Run the new tests AND the two-vm goldens** — `uv run --project tools/controlplane pytest tools/controlplane/tests/test_loadtest_flow.py tools/controlplane/tests/test_two_vm_loadtest_plan.py tools/controlplane/tests/test_two_vm_stack_prelude_argv.py -q`. Expected: PASS, two-vm unchanged. ruff clean.
+
+- [ ] **Step 5: Commit** `feat(loadtest): driver emits ScenarioStepEvents + failure-cleanup + adapter recipe/register (opt-in; multipass unchanged)`.
+
+---
+
+## Phase 3 — ProxmoxLoadtestAdapter + route proxmox
+
+### Task 5: `ProxmoxLoadtestAdapter`
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py`
+- Test: `tools/controlplane/tests/test_loadtest_adapter.py`
+
+Implement `ProxmoxLoadtestAdapter` supplying proxmox's pieces (transcribe from `proxmox_vm_loadtest.py`): `connectivity = ProxmoxConnectivity(...)` (resolved endpoint), `prelude_recipe()` = the filtered `proxmox-vm-loadtest` recipe, `prelude_special_handler`/`prelude_context_selector` = the `cli.fn_apply_selected`→register substitution + `CliComponentContext` selector, `register_functions` = no-op (in prelude), `emits_step_events()` = True, `cleanup_on_failure(exc)` = teardown loadgen+stack (the `_cleanup_proxmox_requests` logic), `extra_steps(BEFORE_LOADGEN, ctx)` = publish prometheus NAT port (+ set `ctx.prometheus_url`), `extra_step_ids(BEFORE_LOADGEN)` = `["vm.stack.publish_ports"]`, `extra_step_titles(BEFORE_LOADGEN)` = `["Publish Proxmox NAT ports"]`, `loadgen_install_endpoint(ctx)` from `ssh_endpoint` (WITH port), `control_plane_url`/`prometheus_url` from the published NAT host/ports, `title_suffix = " (Proxmox)"`.
+
+- [ ] Tests for the adapter's resolution (endpoint with port, title_suffix, extra_step_ids/titles, emits_step_events True, cleanup_on_failure calls teardown). TDD: write, fail, implement, pass, ruff, commit `feat(loadtest): add ProxmoxLoadtestAdapter`.
+
+### Task 6: Route proxmox through the driver; retire the bespoke machinery
+
+**Files:**
+- Modify: `tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py`
+- Tests: the Phase-1 characterization tests + `test_proxmox_prelude_argv.py` + `test_proxmox_vm_loadtest_plan.py` (all stay green)
+
+- [ ] **Step 1: baseline** — run all proxmox tests; confirm green.
+- [ ] **Step 2:** replace `run()` with delegation to `run_loadtest_flow(runner, request, setup, recipe=adapter.prelude_recipe(), adapter=ProxmoxLoadtestAdapter(...), event_listener=event_listener)`; replace `task_ids`/`phase_titles` with delegation to `loadtest_flow_task_ids`/`loadtest_flow_phase_titles`.
+- [ ] **Step 3:** DELETE the retired machinery: `_run_prelude_workflow`, `_run_tail_tasks`, `_tail_tasks`, `_tail_step`, `_emit_tail_event`, `_run_tail_task`, `_skeleton`, `_ActionTask`, `_SkeletonStep`, `_cleanup_proxmox_requests` (logic moved to the adapter), `_register_functions_action` (moved to the adapter's special_handler). KEEP `_build_prelude_tasks` IF `test_proxmox_prelude_argv.py` calls it directly (check — it likely does via `prelude_tasks`); if the adapter now owns prelude building, route the argv golden through the adapter and keep a thin shim, OR keep `_build_prelude_tasks` and have the adapter delegate to it. Decide to keep `test_proxmox_prelude_argv.py` UNCHANGED and green — if that requires keeping `_build_prelude_tasks`/`prelude_tasks`, keep them and have the adapter's `prelude_special_handler`/`context_selector`/recipe mirror them (or call them).
+- [ ] **Step 4:** run characterization tests (Task 1/2) + argv golden + plan tests. ALL must pass unchanged. If the event sequence differs, the driver/adapter is wrong — fix it, do NOT edit the characterization assertions. (Source-inspection guards like `test_proxmox_loadgen_install_uses_runplaybook_not_bash` may need the same retarget as B2/B3a — authorized, preserve the `InstallK6(`-absent invariant.)
+- [ ] **Step 5:** ruff clean; commit `refactor(proxmox): route run() through run_loadtest_flow; retire bespoke machinery`.
+
+---
+
+## Phase 4 — Verify + sweep
+
+### Task 7: Full-suite verification
+
+- [ ] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → PASS.
+- [ ] `git diff main --stat -- tools/controlplane/src/controlplane_tool/scenario/scenarios/two_vm_loadtest.py tools/controlplane/src/controlplane_tool/scenario/scenarios/azure_vm_loadtest.py` → EMPTY (two-vm + azure untouched by B3b).
+- [ ] Confirm proxmox file shrank substantially (retired machinery gone): `wc -l tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py`.
+- [ ] ruff clean on all touched files.
+- [ ] Commit any cleanup.
+
+---
+
+## Real-VM Validation (post-merge — NOT possible for proxmox)
+
+- [ ] Proxmox: NO real hardware — ships argv-golden + characterization-guarded, **flagged unvalidated in the PR**.
+- [ ] multipass two-vm: unaffected by B3b, but re-run its real-VM gate opportunistically since the shared driver changed (Phase 2).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** retire proxmox machinery (§ spec B3b) → Tasks 5-6; characterization-first (user decision) → Tasks 1-2; driver generalization (events/cleanup/recipe/register/extra_step_titles) → Tasks 3-4. The B3a `extra_step_titles` follow-up is fixed in Task 4.
+- **two-vm byte-identity** is the hard invariant for Phase 2: the `emits_step_events()=False` path must be exactly B3a's. Tasks 4 + 7 gate it via the unchanged two-vm goldens + empty-diff check.
+- **Characterization-pins-reality:** Tasks 1-2 assert CURRENT behavior — if an expected list mismatches, fix the EXPECTATION to the captured reality (then it guards the fold), never bend the code in Phase 1.
+- **argv golden untouched:** `test_proxmox_prelude_argv.py` must stay green with an empty diff; Task 6 keeps `_build_prelude_tasks`/`prelude_tasks` if the golden depends on them.
+- **Type consistency:** the adapter members added in Task 3 (`prelude_recipe`/`prelude_special_handler`/`prelude_context_selector`/`register_functions`/`emits_step_events`/`cleanup_on_failure`/`extra_step_titles`/`ensure_stack_task_id`) are implemented by both `MultipassLoadtestAdapter` (Task 3) and `ProxmoxLoadtestAdapter` (Task 5) and consumed by the driver (Task 4) with identical signatures.

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Optional, Protocol
 
 from workflow_tasks.loadtest.ports import RemoteFileFetcher
 from workflow_tasks.tasks.executors import VmCommandRunner
@@ -25,6 +25,7 @@ from controlplane_tool.loadtest.loadtest_adapters import (
 )
 from controlplane_tool.scenario.connectivity import ConnectivityStrategy, MultipassConnectivity
 from controlplane_tool.scenario.loadtest_flow import FlowPhase, RunContext
+from controlplane_tool.scenario.scenarios._workflow_assembly import SpecialHandler
 from controlplane_tool.scenario.two_vm_loadtest_config import (
     two_vm_control_plane_url,
     two_vm_prometheus_url,
@@ -33,6 +34,7 @@ from controlplane_tool.scenario.two_vm_loadtest_config import (
 if TYPE_CHECKING:
     from controlplane_tool.e2e.e2e_models import E2eRequest
     from controlplane_tool.e2e.e2e_runner import E2eRunner
+    from controlplane_tool.scenario.scenarios._workflow_assembly import _Setup
 
 
 @dataclass
@@ -60,6 +62,12 @@ class LoadtestConnectivityAdapter(Protocol):
     def create_run_dir(self) -> Path: ...
     def extra_steps(self, phase: FlowPhase, ctx: RunContext) -> list: ...
     def extra_step_ids(self, phase: FlowPhase) -> list: ...
+    def emits_step_events(self) -> bool: ...
+    def cleanup_on_failure(self, error: Exception) -> list[str]: ...
+    def prelude_special_handler(self, ctx: RunContext) -> Optional[SpecialHandler]: ...
+    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]: ...
+    def register_functions(self, ctx: RunContext) -> None: ...
+    def extra_step_titles(self, phase: FlowPhase) -> list[str]: ...
 
 
 @dataclass
@@ -71,6 +79,7 @@ class MultipassLoadtestAdapter:
     title_suffix: str = ""
     connectivity: ConnectivityStrategy = field(init=False)
     _vm_runner_impl: object = field(default=None, init=False, repr=False)
+    _cached_setup: Optional["_Setup"] = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.connectivity = MultipassConnectivity(runner=self.runner, request=self.request)
@@ -119,3 +128,46 @@ class MultipassLoadtestAdapter:
 
     def extra_step_ids(self, phase: FlowPhase) -> list:
         return []
+
+    # ── New optional-capability methods ────────────────────────────────────
+
+    def emits_step_events(self) -> bool:
+        return False
+
+    def cleanup_on_failure(self, error: Exception) -> list[str]:
+        return []
+
+    def prelude_special_handler(self, ctx: RunContext) -> Optional[SpecialHandler]:
+        return None
+
+    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]:
+        return None
+
+    def extra_step_titles(self, phase: FlowPhase) -> list[str]:
+        return []
+
+    def register_functions(self, ctx: RunContext) -> None:
+        from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
+        from controlplane_tool.scenario.scenario_helpers import function_image, selected_functions
+
+        setup = self._setup()
+        runtime_image_default = f"{setup.context.local_registry}/nanofaas/function-runtime:e2e"
+        RegisterFunctions(
+            task_id="functions.register",
+            title="Register functions",
+            control_plane_url=ctx.control_plane_url,
+            specs=[
+                FunctionSpec(
+                    name=fn_key,
+                    image=function_image(fn_key, self.request.resolved_scenario, runtime_image_default),
+                )
+                for fn_key in selected_functions(self.request.resolved_scenario)
+            ],
+        ).run()
+
+    def _setup(self) -> "_Setup":
+        """Lazily build-and-cache the shared _Setup (avoids double-build when driver provides it)."""
+        if self._cached_setup is None:
+            from controlplane_tool.scenario.scenarios._workflow_assembly import build_setup
+            self._cached_setup = build_setup(self.runner, self.request)
+        return self._cached_setup

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
@@ -68,7 +68,9 @@ class LoadtestConnectivityAdapter(Protocol):
     def emits_step_events(self) -> bool: ...
     def cleanup_on_failure(self, error: Exception) -> list[str]: ...
     def prelude_special_handler(self, ctx: RunContext) -> Optional[SpecialHandler]: ...
-    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]: ...
+    def prelude_context_selector(
+        self, ctx: RunContext, *, resolve_host: bool = True
+    ) -> Optional[object]: ...
     def register_functions(self, ctx: RunContext) -> None: ...
     def extra_step_titles(self, phase: FlowPhase) -> list[str]: ...
 
@@ -151,7 +153,9 @@ class MultipassLoadtestAdapter:
     def prelude_special_handler(self, ctx: RunContext) -> Optional[SpecialHandler]:
         return None
 
-    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]:
+    def prelude_context_selector(
+        self, ctx: RunContext, *, resolve_host: bool = True
+    ) -> Optional[object]:
         return None
 
     def extra_step_titles(self, phase: FlowPhase) -> list[str]:
@@ -333,14 +337,16 @@ class ProxmoxLoadtestAdapter:
 
         return action
 
-    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]:
+    def prelude_context_selector(
+        self, ctx: RunContext, *, resolve_host: bool = True
+    ) -> Optional[object]:
         from pathlib import Path as _Path
         from typing import cast
 
         from controlplane_tool.scenario.components.cli import CliComponentContext
 
         context = self._resolve_context()
-        conn = self.connectivity_for(ctx, resolve_host=True)
+        conn = self.connectivity_for(ctx, resolve_host=resolve_host)
         cli_context = CliComponentContext(
             repo_root=_Path(conn.remote_dir_value),
             release=cast(str, context.release),

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_adapter.py
@@ -51,6 +51,9 @@ class LoadtestConnectivityAdapter(Protocol):
     title_suffix: str
     connectivity: ConnectivityStrategy
 
+    def connectivity_for(
+        self, ctx: "RunContext | None", *, resolve_host: bool
+    ) -> ConnectivityStrategy: ...
     def stack_lifecycle(self): ...
     def loadgen_lifecycle(self): ...
     def loadgen_install_endpoint(self, ctx: RunContext) -> InstallEndpoint: ...
@@ -83,6 +86,14 @@ class MultipassLoadtestAdapter:
 
     def __post_init__(self) -> None:
         self.connectivity = MultipassConnectivity(runner=self.runner, request=self.request)
+
+    def connectivity_for(
+        self, ctx: "RunContext | None", *, resolve_host: bool
+    ) -> ConnectivityStrategy:
+        # Multipass resolves IPs lazily inside build_command_tasks; resolve_host is
+        # honored there via the call site, so the static MultipassConnectivity is
+        # correct regardless of ctx/resolve_host.
+        return self.connectivity
 
     def _runner_impl(self):
         if self._vm_runner_impl is None:
@@ -171,3 +182,289 @@ class MultipassLoadtestAdapter:
             from controlplane_tool.scenario.scenarios._workflow_assembly import build_setup
             self._cached_setup = build_setup(self.runner, self.request)
         return self._cached_setup
+
+
+@dataclass
+class ProxmoxLoadtestAdapter:
+    """Proxmox: rewrites host-ops onto the published NAT SSH endpoint and publishes
+    NAT ports for the control plane (in the prelude special_handler, alongside
+    function registration) and prometheus (in a BEFORE_LOADGEN extra step).
+
+    Mirrors the connectivity/registration/publish/cleanup pieces of the legacy
+    ``ProxmoxVmLoadtestPlan``. Constructed lazily over a
+    ``ProxmoxVmOrchestrator(repo_root=runner.paths.workspace_root)``.
+    """
+
+    runner: "E2eRunner"
+    request: "E2eRequest"
+    title_suffix: str = " (Proxmox)"
+    connectivity: ConnectivityStrategy = field(default=None, init=False)  # type: ignore[assignment]
+    _proxmox_orch: object = field(default=None, init=False, repr=False)
+    _published_cp: "tuple[str, int] | None" = field(default=None, init=False, repr=False)
+
+    def _orch(self):
+        if self._proxmox_orch is None:
+            from controlplane_tool.infra.vm.proxmox_vm_adapter import ProxmoxVmOrchestrator
+
+            self._proxmox_orch = ProxmoxVmOrchestrator(
+                repo_root=self.runner.paths.workspace_root
+            )
+        return self._proxmox_orch
+
+    @property
+    def _stack_request(self):
+        if self.request.vm is None:
+            raise ValueError("proxmox loadtest requires a stack VM request")
+        return self.request.vm
+
+    @property
+    def _loadgen_request(self):
+        if self.request.loadgen_vm is None:
+            raise ValueError("proxmox loadtest requires a loadgen VM request")
+        return self.request.loadgen_vm
+
+    # ── connectivity ────────────────────────────────────────────────────────
+
+    def connectivity_for(
+        self, ctx: Optional[RunContext], *, resolve_host: bool
+    ) -> ConnectivityStrategy:
+        from controlplane_tool.scenario.connectivity import ProxmoxConnectivity
+
+        orch = self._orch()
+        stack_request = self._stack_request
+        if resolve_host:
+            remote_dir = orch.remote_project_dir(stack_request)
+            host, port = orch.ssh_endpoint(stack_request)
+            key = orch.ssh_private_key_path(stack_request)
+        else:
+            remote_dir = f"/home/{stack_request.user or 'ubuntu'}/nanofaas"
+            host, port = "<proxmox-host>", 0
+            key = None
+        return ProxmoxConnectivity(
+            orchestrator=orch,
+            request=stack_request,
+            host=host,
+            port=port,
+            key=key,
+            repo_root=self.runner.paths.workspace_root,
+            remote_dir_value=remote_dir,
+        )
+
+    # ── prelude special handler + context selector ──────────────────────────
+
+    def _resolve_context(self):
+        from controlplane_tool.scenario.components.environment import (
+            resolve_scenario_environment,
+        )
+
+        return resolve_scenario_environment(
+            self.runner.paths.workspace_root,
+            self.request,
+            manifest_root=self.runner.manifest_root,
+        )
+
+    def prelude_special_handler(self, ctx: RunContext) -> Optional[SpecialHandler]:
+        from controlplane_tool.scenario.scenarios._workflow_assembly import (
+            HANDLED,
+            CallableTask,
+        )
+        from controlplane_tool.scenario.two_vm_loadtest_config import LOADTEST_SCENARIOS
+
+        context = self._resolve_context()
+        registered = {"done": False}
+
+        def special_handler(operation):
+            if (
+                operation.operation_id.startswith("cli.fn_apply_selected")
+                and self.request.scenario in LOADTEST_SCENARIOS
+            ):
+                if not registered["done"]:
+                    registered["done"] = True
+                    return CallableTask(
+                        task_id="functions.register",
+                        title="Register selected functions via REST API",
+                        action=self._register_functions_action(context),
+                    )
+                return HANDLED
+            return None
+
+        return special_handler
+
+    def _register_functions_action(self, context):
+        from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
+        from controlplane_tool.scenario.scenario_helpers import (
+            function_image,
+            selected_functions,
+        )
+        from controlplane_tool.scenario.two_vm_loadtest_config import (
+            TWO_VM_CONTROL_PLANE_HTTP_NODE_PORT,
+        )
+
+        request = self.request
+        orch = self._orch()
+        stack_request = self._stack_request
+
+        def action() -> None:
+            runtime_image_default = (
+                f"{context.local_registry}/nanofaas/function-runtime:e2e"
+            )
+            specs = [
+                FunctionSpec(
+                    name=fn_key,
+                    image=function_image(
+                        fn_key, request.resolved_scenario, runtime_image_default
+                    ),
+                )
+                for fn_key in selected_functions(request.resolved_scenario)
+            ]
+            cp_host, cp_port = orch.publish_port(
+                stack_request,
+                service="CONTROL_PLANE_HTTP",
+                guest_port=TWO_VM_CONTROL_PLANE_HTTP_NODE_PORT,
+            )
+            self._published_cp = (cp_host, cp_port)
+            cp_url = f"http://{cp_host}:{cp_port}"
+            RegisterFunctions(
+                task_id="functions.register",
+                title="Register functions",
+                control_plane_url=cp_url,
+                specs=specs,
+            ).run()
+
+        return action
+
+    def prelude_context_selector(self, ctx: RunContext) -> Optional[object]:
+        from pathlib import Path as _Path
+        from typing import cast
+
+        from controlplane_tool.scenario.components.cli import CliComponentContext
+
+        context = self._resolve_context()
+        conn = self.connectivity_for(ctx, resolve_host=True)
+        cli_context = CliComponentContext(
+            repo_root=_Path(conn.remote_dir_value),
+            release=cast(str, context.release),
+            namespace=cast(str, context.namespace),
+            local_registry=context.local_registry,
+            resolved_scenario=context.resolved_scenario,
+            control_plane_endpoint=None,
+        )
+
+        def context_selector(component):
+            return cli_context if component.component_id.startswith("cli.") else context
+
+        return context_selector
+
+    def register_functions(self, ctx: RunContext) -> None:
+        # No-op: registration is performed in the prelude via the special_handler.
+        return None
+
+    # ── lifecycles ───────────────────────────────────────────────────────────
+
+    def stack_lifecycle(self):
+        from controlplane_tool.infra.vm_lifecycle_adapters import ProxmoxVmAdapter
+
+        return ProxmoxVmAdapter(self._orch(), credentials=self._stack_request)
+
+    def loadgen_lifecycle(self):
+        from controlplane_tool.infra.vm_lifecycle_adapters import ProxmoxVmAdapter
+
+        return ProxmoxVmAdapter(self._orch(), credentials=self._loadgen_request)
+
+    # ── loadgen body collaborators ─────────────────────────────────────────────
+
+    def loadgen_install_endpoint(self, ctx: RunContext) -> InstallEndpoint:
+        orch = self._orch()
+        loadgen_request = self._loadgen_request
+        host, port = orch.ssh_endpoint(loadgen_request)
+        return InstallEndpoint(
+            host=host,
+            user=loadgen_request.user,
+            private_key=orch.ssh_private_key_path(loadgen_request),
+            port=port,
+        )
+
+    def loadgen_runner(self, ctx: RunContext) -> VmCommandRunner:
+        return OrchestratorVmRunner(self._orch(), self._loadgen_request)
+
+    def fetcher(self, ctx: RunContext) -> RemoteFileFetcher:
+        return VmFileFetcher(vm=self._orch(), request=self._loadgen_request)
+
+    def control_plane_url(self, ctx: RunContext) -> str:
+        return two_vm_control_plane_url(self._stack_request, host=ctx.stack_host)
+
+    def prometheus_url(self, ctx: RunContext) -> str:
+        return ctx.prometheus_url
+
+    def prepare_loadgen(self, ctx: RunContext) -> None:
+        # Proxmox builds the loadgen body directly (no separate script-upload /
+        # prepare step in its tail) — no-op.
+        return None
+
+    def create_run_dir(self) -> Path:
+        from typing import Any, cast
+
+        from controlplane_tool.e2e.two_vm_loadtest_runner import TwoVmLoadtestRunner
+
+        run_dir_creator = TwoVmLoadtestRunner(
+            repo_root=self.runner.paths.workspace_root, vm=cast("Any", self._orch())
+        )
+        return run_dir_creator._create_run_dir()  # noqa: SLF001
+
+    # ── lifecycle-specific extra steps ─────────────────────────────────────────
+
+    def extra_steps(self, phase: FlowPhase, ctx: RunContext) -> list:
+        if phase is FlowPhase.BEFORE_LOADGEN:
+            from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
+            from controlplane_tool.scenario.two_vm_loadtest_config import (
+                TWO_VM_PROMETHEUS_NODE_PORT,
+            )
+
+            orch = self._orch()
+            stack_request = self._stack_request
+
+            def action() -> None:
+                host, port = orch.publish_port(
+                    stack_request,
+                    service="PROMETHEUS",
+                    guest_port=TWO_VM_PROMETHEUS_NODE_PORT,
+                )
+                ctx.prometheus_url = f"http://{host}:{port}"
+
+            return [
+                CallableTask(
+                    task_id="vm.stack.publish_ports",
+                    title="Publish Proxmox NAT ports",
+                    action=action,
+                )
+            ]
+        return []
+
+    def extra_step_ids(self, phase: FlowPhase) -> list:
+        if phase is FlowPhase.BEFORE_LOADGEN:
+            return ["vm.stack.publish_ports"]
+        return []
+
+    def extra_step_titles(self, phase: FlowPhase) -> list[str]:
+        if phase is FlowPhase.BEFORE_LOADGEN:
+            return ["Publish Proxmox NAT ports"]
+        return []
+
+    # ── event/cleanup capabilities ─────────────────────────────────────────────
+
+    def emits_step_events(self) -> bool:
+        return True
+
+    def cleanup_on_failure(self, error: Exception) -> list[str]:
+        if not self.request.cleanup_vm:
+            return []
+        orch = self._orch()
+        errors: list[str] = []
+        for vm_request in (self.request.loadgen_vm, self.request.vm):
+            if vm_request is None:
+                continue
+            try:
+                orch.teardown(vm_request)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(str(exc))
+        return errors

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
@@ -88,25 +88,6 @@ def _two_vm_remote_paths_for(request, ctx: RunContext):
     )
 
 
-def _register_functions(runner, request, setup, ctx: RunContext) -> None:
-    from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
-    from controlplane_tool.scenario.scenario_helpers import function_image, selected_functions
-
-    runtime_image_default = f"{setup.context.local_registry}/nanofaas/function-runtime:e2e"
-    RegisterFunctions(
-        task_id="functions.register",
-        title="Register functions",
-        control_plane_url=ctx.control_plane_url,
-        specs=[
-            FunctionSpec(
-                name=fn_key,
-                image=function_image(fn_key, request.resolved_scenario, runtime_image_default),
-            )
-            for fn_key in selected_functions(request.resolved_scenario)
-        ],
-    ).run()
-
-
 _LOADGEN_BODY_IDS = (
     "loadgen.install_k6",
     "loadgen.run_k6",

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
@@ -70,6 +70,16 @@ def _run_workflow(tasks: list, cleanup_tasks: list | None = None) -> None:
     Workflow(tasks=tasks, cleanup_tasks=cleanup_tasks or []).run()
 
 
+def _adapter_connectivity(adapter, ctx, *, resolve_host: bool):
+    """adapter.connectivity_for is the generalized resolver (added in Task 5); fall
+    back to the static adapter.connectivity attribute for adapters/fakes that
+    predate it."""
+    fn = getattr(adapter, "connectivity_for", None)
+    if fn is not None:
+        return fn(ctx, resolve_host=resolve_host)
+    return adapter.connectivity
+
+
 def _two_vm_remote_paths_for(request, ctx: RunContext):
     from controlplane_tool.scenario.two_vm_loadtest_config import two_vm_remote_paths
     return two_vm_remote_paths(
@@ -282,7 +292,9 @@ def _run_loadtest_flow_native(*, runner, request, setup, recipe, adapter) -> Non
     ctx.stack_host = getattr(ctx.stack_info, "host", None)
 
     # ── 2. Stack provisioning prelude + adapter extra steps ─────────────────
-    prelude = _build_prelude_tasks(runner, request, setup, recipe, adapter.connectivity)
+    prelude = _build_prelude_tasks(
+        runner, request, setup, recipe, _adapter_connectivity(adapter, ctx, resolve_host=True)
+    )
     prelude += adapter.extra_steps(FlowPhase.AFTER_STACK_READY, ctx)
     _run_workflow(prelude)
 
@@ -351,7 +363,8 @@ def _run_loadtest_flow_emitting(*, runner, request, setup, recipe, adapter, even
     # adapter.cleanup_on_failure() and re-raise a scenario-formatted error.
     try:
         prelude = _build_prelude_tasks(
-            runner, request, setup, recipe, adapter.connectivity,
+            runner, request, setup, recipe,
+            _adapter_connectivity(adapter, ctx, resolve_host=True),
             special_handler=adapter.prelude_special_handler(ctx),
             context_selector=adapter.prelude_context_selector(ctx),
         )
@@ -433,7 +446,9 @@ def _prelude_static_ids(runner, request, setup, recipe, connectivity) -> list:
 def loadtest_flow_task_ids(*, runner, request, setup, recipe, adapter) -> list:
     """Return the ordered list of task_id strings for the static (dry-run) plan."""
     ids = ["vm.stack.ensure_running"]
-    ids += _prelude_static_ids(runner, request, setup, recipe, adapter.connectivity)
+    ids += _prelude_static_ids(
+        runner, request, setup, recipe, _adapter_connectivity(adapter, None, resolve_host=False)
+    )
     ids += list(adapter.extra_step_ids(FlowPhase.AFTER_STACK_READY))
     ids += ["vm.loadgen.ensure_running"]
     ids += list(adapter.extra_step_ids(FlowPhase.BEFORE_LOADGEN))
@@ -446,7 +461,13 @@ def loadtest_flow_phase_titles(*, runner, request, setup, recipe, adapter) -> li
     """Return the ordered list of phase title strings for the static (dry-run) plan."""
     s = adapter.title_suffix
     titles = [f"Ensure stack VM running{s}"]
-    titles += [t.title for t in _prelude_static_tasks(runner, request, setup, recipe, adapter.connectivity)]
+    titles += [
+        t.title
+        for t in _prelude_static_tasks(
+            runner, request, setup, recipe,
+            _adapter_connectivity(adapter, None, resolve_host=False),
+        )
+    ]
     titles += list(_adapter_extra_titles(adapter, FlowPhase.AFTER_STACK_READY))
     titles += [f"Ensure loadgen VM running{s}"]
     titles += list(_adapter_extra_titles(adapter, FlowPhase.BEFORE_LOADGEN))

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
@@ -434,20 +434,57 @@ def _emitting_failure_cleanup(adapter, request, exc: Exception):
 # Kept as module-level functions so tests can monkeypatch them.
 # ---------------------------------------------------------------------------
 
-def _prelude_static_tasks(runner, request, setup, recipe, connectivity) -> list:
+def _static_prelude_hooks(adapter):
+    """Resolve the adapter's prelude special_handler/context_selector for the static
+    (resolve_host=False) plan. Adapters without these capabilities (multipass) yield
+    (None, None) so the static path is byte-identical to before."""
+    sh_fn = getattr(adapter, "prelude_special_handler", None)
+    cs_fn = getattr(adapter, "prelude_context_selector", None)
+    special_handler = sh_fn(None) if sh_fn is not None else None
+    context_selector = cs_fn(None, resolve_host=False) if cs_fn is not None else None
+    return special_handler, context_selector
+
+
+def _prelude_static_tasks(runner, request, setup, recipe, connectivity,
+                          special_handler=None, context_selector=None) -> list:
     from controlplane_tool.scenario.scenarios._workflow_assembly import build_command_tasks
-    return build_command_tasks(runner, request, setup, recipe, connectivity=connectivity, resolve_host=False)
+    return build_command_tasks(
+        runner, request, setup, recipe,
+        connectivity=connectivity, resolve_host=False,
+        special_handler=special_handler, context_selector=context_selector,
+    )
 
 
-def _prelude_static_ids(runner, request, setup, recipe, connectivity) -> list:
-    return [t.task_id for t in _prelude_static_tasks(runner, request, setup, recipe, connectivity)]
+def _prelude_static_ids(runner, request, setup, recipe, connectivity,
+                        special_handler=None, context_selector=None) -> list:
+    return [
+        t.task_id
+        for t in _prelude_static_tasks(
+            runner, request, setup, recipe, connectivity,
+            special_handler=special_handler, context_selector=context_selector,
+        )
+    ]
+
+
+def _static_hook_kwargs(adapter) -> dict:
+    """Only-non-None hooks, so the no-hook (multipass) call site stays byte-identical
+    (no extra kwargs passed) and the monkeypatched 5-arg test doubles keep working."""
+    special_handler, context_selector = _static_prelude_hooks(adapter)
+    kwargs = {}
+    if special_handler is not None:
+        kwargs["special_handler"] = special_handler
+    if context_selector is not None:
+        kwargs["context_selector"] = context_selector
+    return kwargs
 
 
 def loadtest_flow_task_ids(*, runner, request, setup, recipe, adapter) -> list:
     """Return the ordered list of task_id strings for the static (dry-run) plan."""
     ids = ["vm.stack.ensure_running"]
     ids += _prelude_static_ids(
-        runner, request, setup, recipe, _adapter_connectivity(adapter, None, resolve_host=False)
+        runner, request, setup, recipe,
+        _adapter_connectivity(adapter, None, resolve_host=False),
+        **_static_hook_kwargs(adapter),
     )
     ids += list(adapter.extra_step_ids(FlowPhase.AFTER_STACK_READY))
     ids += ["vm.loadgen.ensure_running"]
@@ -466,6 +503,7 @@ def loadtest_flow_phase_titles(*, runner, request, setup, recipe, adapter) -> li
         for t in _prelude_static_tasks(
             runner, request, setup, recipe,
             _adapter_connectivity(adapter, None, resolve_host=False),
+            **_static_hook_kwargs(adapter),
         )
     ]
     titles += list(_adapter_extra_titles(adapter, FlowPhase.AFTER_STACK_READY))

--- a/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/loadtest_flow.py
@@ -43,15 +43,27 @@ class RunContext:
 # without touching heavy collaborators.
 # ---------------------------------------------------------------------------
 
+def _ensure_vm_task(task_id: str, title: str, lifecycle, config):
+    """Build (do NOT run) the EnsureVmRunning task — kept separate so the driver
+    can run it via either the native workflow_step path or the event-emitting path."""
+    return EnsureVmRunning(task_id=task_id, title=title, lifecycle=lifecycle, config=config)
+
+
 def _ensure_vm(task_id: str, title: str, lifecycle, config):
-    task = EnsureVmRunning(task_id=task_id, title=title, lifecycle=lifecycle, config=config)
+    task = _ensure_vm_task(task_id, title, lifecycle, config)
     with workflow_step(task_id=task.task_id, title=task.title):
         return task.run()
 
 
-def _build_prelude_tasks(runner, request, setup, recipe, connectivity) -> list:
+def _build_prelude_tasks(runner, request, setup, recipe, connectivity,
+                         special_handler=None, context_selector=None) -> list:
     from controlplane_tool.scenario.scenarios._workflow_assembly import build_command_tasks
-    return build_command_tasks(runner, request, setup, recipe, connectivity=connectivity)
+    return build_command_tasks(
+        runner, request, setup, recipe,
+        connectivity=connectivity,
+        special_handler=special_handler,
+        context_selector=context_selector,
+    )
 
 
 def _run_workflow(tasks: list, cleanup_tasks: list | None = None) -> None:
@@ -148,6 +160,80 @@ def _loadgen_vm_config(request):
     return VmConfig(name=lg.name or "", cpus=lg.cpus, memory=lg.memory, disk=lg.disk)
 
 
+class _StepEmitter:
+    """Emits ScenarioStepEvent(running -> success/failed) per executed task.
+
+    Threads a sequential step_index across the whole flow; total_steps is the
+    length of the static plan. Used only when adapter.emits_step_events() is True;
+    the multipass path never constructs one (it uses the native workflow_step path).
+    """
+
+    def __init__(self, event_listener, total_steps: int) -> None:
+        self._listener = event_listener
+        self._total = total_steps
+        self._index = 0
+
+    def _step(self, task):
+        from controlplane_tool.scenario.components.executor import ScenarioPlanStep
+        return ScenarioPlanStep(
+            summary=task.title,
+            command=["python", "-c", f"# {task.task_id}"],
+            step_id=task.task_id,
+        )
+
+    def _emit(self, step_index, task, status, error=None) -> None:
+        if self._listener is None:
+            return
+        from controlplane_tool.e2e.e2e_runner import ScenarioStepEvent
+        self._listener(
+            ScenarioStepEvent(
+                step_index=step_index,
+                total_steps=self._total,
+                step=self._step(task),
+                status=status,
+                error=error,
+            )
+        )
+
+    def run_task(self, task):
+        """Run a single task wrapped in running/success/failed emission."""
+        self._index += 1
+        idx = self._index
+        self._emit(idx, task, "running")
+        try:
+            result = task.run()
+        except Exception as exc:
+            self._emit(idx, task, "failed", error=str(exc))
+            # Tag the failing step's title so the path-(a) cleanup wrapper can
+            # format the scenario error exactly like proxmox's _run_prelude_workflow.
+            try:
+                exc.loadtest_step_title = task.title  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+        self._emit(idx, task, "success")
+        return result
+
+    def run_tasks(self, tasks: list, cleanup_tasks: list | None = None):
+        """Run a list of body tasks, then cleanup tasks. On a body failure the
+        cleanup tasks still run (native Workflow semantics), and the original
+        error is re-raised unwrapped — matching the proxmox tail path."""
+        main_error: BaseException | None = None
+        for task in tasks:
+            try:
+                self.run_task(task)
+            except BaseException as exc:  # noqa: BLE001
+                main_error = exc
+                break
+        for task in cleanup_tasks or []:
+            try:
+                self.run_task(task)
+            except Exception:  # noqa: BLE001
+                pass
+        if main_error is not None:
+            raise main_error
+
+
 def run_loadtest_flow(*, runner, request, setup, recipe, adapter, event_listener=None) -> None:
     """7-phase lifecycle-generic loadtest driver.
 
@@ -159,7 +245,30 @@ def run_loadtest_flow(*, runner, request, setup, recipe, adapter, event_listener
     5. register functions on control plane
     6. loadgen body workflow (install-k6, run-k6, fetch, prometheus, report)
     7. cleanup (destroy VMs if cleanup_vm)
+
+    Two emission modes (selected by ``adapter.emits_step_events()``):
+    - False (multipass): the historical native ``workflow_step`` / ``Workflow``
+      path, byte-for-byte unchanged; ``event_listener`` is ignored and no
+      failure-cleanup wrapping is applied.
+    - True (proxmox et al.): each executed task is wrapped to emit
+      ``ScenarioStepEvent`` running/success/failed with a sequential ``step_index``
+      and constant ``total_steps``, and the ensure/prelude/register region is
+      wrapped so a failure triggers ``adapter.cleanup_on_failure`` + a scenario-
+      formatted error.
     """
+    if adapter.emits_step_events():
+        _run_loadtest_flow_emitting(
+            runner=runner, request=request, setup=setup, recipe=recipe,
+            adapter=adapter, event_listener=event_listener,
+        )
+    else:
+        _run_loadtest_flow_native(
+            runner=runner, request=request, setup=setup, recipe=recipe, adapter=adapter,
+        )
+
+
+def _run_loadtest_flow_native(*, runner, request, setup, recipe, adapter) -> None:
+    """Historical two-vm/multipass path — MUST stay byte-identical to B3a."""
     s = adapter.title_suffix
     ctx = RunContext()
 
@@ -197,27 +306,114 @@ def run_loadtest_flow(*, runner, request, setup, recipe, adapter, event_listener
     adapter.prepare_loadgen(ctx)
 
     # ── 5. Register functions on control plane ──────────────────────────────
-    _register_functions(runner, request, setup, ctx)
+    adapter.register_functions(ctx)
 
     # ── 6. Loadgen body workflow ────────────────────────────────────────────
     body = _build_loadgen_body(runner, request, adapter, ctx)
-    cleanup: list = []
-    if getattr(request, "cleanup_vm", True):
-        cleanup = [
-            DestroyVm(
-                task_id="vm.loadgen.destroy",
-                title=f"Destroy loadgen VM{s}",
-                lifecycle=adapter.loadgen_lifecycle(),
-                info=ctx.loadgen_info,
-            ),
-            DestroyVm(
-                task_id="vm.stack.destroy",
-                title=f"Destroy stack VM{s}",
-                lifecycle=adapter.stack_lifecycle(),
-                info=ctx.stack_info,
-            ),
-        ]
+    cleanup = _destroy_tasks(adapter, ctx, request)
     _run_workflow(body, cleanup_tasks=cleanup)
+
+
+def _destroy_tasks(adapter, ctx: RunContext, request) -> list:
+    s = adapter.title_suffix
+    if not getattr(request, "cleanup_vm", True):
+        return []
+    return [
+        DestroyVm(
+            task_id="vm.loadgen.destroy",
+            title=f"Destroy loadgen VM{s}",
+            lifecycle=adapter.loadgen_lifecycle(),
+            info=ctx.loadgen_info,
+        ),
+        DestroyVm(
+            task_id="vm.stack.destroy",
+            title=f"Destroy stack VM{s}",
+            lifecycle=adapter.stack_lifecycle(),
+            info=ctx.stack_info,
+        ),
+    ]
+
+
+def _run_loadtest_flow_emitting(*, runner, request, setup, recipe, adapter, event_listener) -> None:
+    """Event-emitting path (proxmox et al.): emits ScenarioStepEvents per task and
+    applies failure-cleanup (path a) around the ensure/prelude/register region."""
+    s = adapter.title_suffix
+    ctx = RunContext()
+    emitter = _StepEmitter(
+        event_listener,
+        total_steps=len(loadtest_flow_task_ids(
+            runner=runner, request=request, setup=setup, recipe=recipe, adapter=adapter,
+        )),
+    )
+
+    # ── ensure-stack -> prelude -> ensure-loadgen -> prepare -> register ─────
+    # Wrapped in failure-cleanup (path a): on any exception, run
+    # adapter.cleanup_on_failure() and re-raise a scenario-formatted error.
+    try:
+        prelude = _build_prelude_tasks(
+            runner, request, setup, recipe, adapter.connectivity,
+            special_handler=adapter.prelude_special_handler(ctx),
+            context_selector=adapter.prelude_context_selector(ctx),
+        )
+        for task in prelude:
+            emitter.run_task(task)
+
+        stack_task = _ensure_vm_task(
+            "vm.stack.ensure_running",
+            f"Ensure stack VM running{s}",
+            adapter.stack_lifecycle(),
+            setup.vm_config,
+        )
+        ctx.stack_info = emitter.run_task(stack_task)
+        ctx.stack_host = getattr(ctx.stack_info, "host", None)
+
+        for task in adapter.extra_steps(FlowPhase.AFTER_STACK_READY, ctx):
+            emitter.run_task(task)
+
+        loadgen_task = _ensure_vm_task(
+            "vm.loadgen.ensure_running",
+            f"Ensure loadgen VM running{s}",
+            adapter.loadgen_lifecycle(),
+            _loadgen_vm_config(request),
+        )
+        ctx.loadgen_info = emitter.run_task(loadgen_task)
+
+        ctx.remote_paths = _two_vm_remote_paths_for(request, ctx)
+        ctx.run_dir = adapter.create_run_dir()
+        ctx.control_plane_url = adapter.control_plane_url(ctx)
+        ctx.prometheus_url = adapter.prometheus_url(ctx)
+
+        for task in adapter.extra_steps(FlowPhase.BEFORE_LOADGEN, ctx):
+            emitter.run_task(task)
+        adapter.prepare_loadgen(ctx)
+
+        adapter.register_functions(ctx)
+    except Exception as exc:
+        _emitting_failure_cleanup(adapter, request, exc)
+        raise  # unreachable: _emitting_failure_cleanup always raises
+
+    # ── body + cleanup: native Workflow cleanup semantics (path b) ──────────
+    body = _build_loadgen_body(runner, request, adapter, ctx)
+    cleanup = _destroy_tasks(adapter, ctx, request)
+    emitter.run_tasks(body, cleanup_tasks=cleanup)
+
+
+def _emitting_failure_cleanup(adapter, request, exc: Exception):
+    """Path (a) failure handling: run adapter.cleanup_on_failure() and raise a
+    scenario-formatted error joined with any cleanup errors. Always raises."""
+    title = getattr(exc, "loadtest_step_title", None)
+    wrapped = (
+        f"Scenario '{getattr(request, 'scenario', '?')}' failed at step "
+        f"'{title}': {exc}"
+        if title is not None
+        else f"Scenario '{getattr(request, 'scenario', '?')}' failed: {exc}"
+    )
+    cleanup_errors = adapter.cleanup_on_failure(exc)
+    if cleanup_errors:
+        raise RuntimeError(
+            f"{wrapped}\n\nCleanup failed:\n" + "\n".join(cleanup_errors)
+        ) from exc
+    raise RuntimeError(wrapped) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +447,16 @@ def loadtest_flow_phase_titles(*, runner, request, setup, recipe, adapter) -> li
     s = adapter.title_suffix
     titles = [f"Ensure stack VM running{s}"]
     titles += [t.title for t in _prelude_static_tasks(runner, request, setup, recipe, adapter.connectivity)]
+    titles += list(_adapter_extra_titles(adapter, FlowPhase.AFTER_STACK_READY))
     titles += [f"Ensure loadgen VM running{s}"]
+    titles += list(_adapter_extra_titles(adapter, FlowPhase.BEFORE_LOADGEN))
     titles += [f"{base}{s}" for base in _LOADGEN_BODY_BASE_TITLES]
     titles += [f"Destroy loadgen VM{s}", f"Destroy stack VM{s}"]
     return titles
+
+
+def _adapter_extra_titles(adapter, phase: FlowPhase) -> list:
+    """adapter.extra_step_titles is an optional capability (added in Task 3); fall
+    back to [] for adapters/fakes that predate it."""
+    fn = getattr(adapter, "extra_step_titles", None)
+    return list(fn(phase)) if fn is not None else []

--- a/tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py
+++ b/tools/controlplane/src/controlplane_tool/scenario/scenarios/proxmox_vm_loadtest.py
@@ -2,62 +2,42 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
-
-from workflow_tasks import (
-    CapturePrometheusSnapshot,
-    DestroyVm,
-    EnsureVmRunning,
-    FetchVmResults,
-    InstallK6,
-    LoadgenBodyInputs,
-    RunK6,
-    Workflow,
-    WriteK6Report,
-    build_loadgen_body_tasks,
-    make_loadtest_k6_config,
-    workflow_step,
-)
-from workflow_tasks.loadtest.models import K6Config
-from workflow_tasks.vm.models import VmConfig
+from typing import TYPE_CHECKING, cast
 
 from controlplane_tool.e2e.e2e_models import E2eRequest
 from controlplane_tool.infra.vm.vm_models import VmRequest
-from controlplane_tool.infra.vm_lifecycle_adapters import ProxmoxVmAdapter, VmLifecycleAdapter
-from controlplane_tool.loadtest.loadtest_adapters import (
-    HttpPrometheusClient,
-    OrchestratorVmRunner,
-    VmFileFetcher,
-)
 from controlplane_tool.scenario.catalog import ScenarioDefinition
 from controlplane_tool.scenario.components.cli import CliComponentContext
 from controlplane_tool.scenario.components.environment import resolve_scenario_environment
 from controlplane_tool.scenario.components.executor import ScenarioPlanStep
 from controlplane_tool.scenario.components.recipes import build_scenario_recipe
-from controlplane_tool.scenario.scenario_helpers import function_image, selected_functions
 from controlplane_tool.scenario.connectivity import ProxmoxConnectivity
+from controlplane_tool.scenario.loadtest_adapter import ProxmoxLoadtestAdapter
+from controlplane_tool.scenario.loadtest_flow import (
+    loadtest_flow_phase_titles,
+    loadtest_flow_task_ids,
+    run_loadtest_flow,
+)
+from controlplane_tool.scenario.scenario_helpers import function_image, selected_functions
 from controlplane_tool.scenario.scenarios._workflow_assembly import (
     HANDLED,
     CallableTask,
     build_command_tasks,
     build_setup,
 )
-from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
 from controlplane_tool.scenario.two_vm_loadtest_config import (
-    LOADTEST_PROMETHEUS_QUERIES,
     LOADTEST_SCENARIOS,
     TWO_VM_CONTROL_PLANE_HTTP_NODE_PORT,
-    TWO_VM_PROMETHEUS_NODE_PORT,
-    two_vm_control_plane_url,
-    two_vm_load_stages,
-    two_vm_remote_paths,
-    two_vm_target_function,
 )
+from workflow_tasks.components.function_tasks import FunctionSpec, RegisterFunctions
 
 if TYPE_CHECKING:
     from controlplane_tool.e2e.e2e_runner import E2eRunner
 
 
+# Components run on the stack VM before loadgen starts.
+# vm.ensure_running is handled separately (EnsureVmRunning task outside the prelude
+# Workflow) by the unified driver, so it is NOT part of the prelude recipe.
 _PROXMOX_LOADTEST_PRELUDE_COMPONENTS = (
     "vm.ensure_running",
     "vm.provision_base",
@@ -75,22 +55,6 @@ _PROXMOX_LOADTEST_PRELUDE_COMPONENTS = (
 )
 
 
-@dataclass(frozen=True)
-class _SkeletonStep:
-    task_id: str
-    title: str
-
-
-@dataclass(frozen=True)
-class _ActionTask:
-    task_id: str
-    title: str
-    action: Callable[[], Any]
-
-    def run(self) -> Any:
-        return self.action()
-
-
 @dataclass
 class ProxmoxVmLoadtestPlan:
     scenario: ScenarioDefinition
@@ -98,75 +62,67 @@ class ProxmoxVmLoadtestPlan:
     steps: list[ScenarioPlanStep]
     runner: "E2eRunner" = field(repr=False, compare=False)
 
+    # ── unified-driver delegation ────────────────────────────────────────────
+
     @property
     def task_ids(self) -> list[str]:
-        pre, wf = self._skeleton()
-        return self._display_prelude_task_ids() + [t.task_id for t in pre] + wf.task_ids
+        return loadtest_flow_task_ids(
+            runner=self.runner,
+            request=self.request,
+            setup=build_setup(self.runner, self.request),
+            recipe=self._recipe(),
+            adapter=self._adapter(),
+        )
 
     @property
     def phase_titles(self) -> list[str]:
-        pre, wf = self._skeleton()
-        return self._display_prelude_titles() + [t.title for t in pre] + wf.phase_titles
+        return loadtest_flow_phase_titles(
+            runner=self.runner,
+            request=self.request,
+            setup=build_setup(self.runner, self.request),
+            recipe=self._recipe(),
+            adapter=self._adapter(),
+        )
 
-    def _display_prelude_tasks(self) -> list:
-        """Honest prelude Tasks built WITHOUT a live VM (for task_ids/titles).
+    def _adapter(self) -> ProxmoxLoadtestAdapter:
+        return ProxmoxLoadtestAdapter(runner=self.runner, request=self.request)
 
-        Uses ``resolve_host=False`` so no proxmox SSH endpoint is resolved — the
-        TUI only needs the ordered task_ids/titles, not resolved commands.
+    def _recipe(self):
+        """The proxmox prelude recipe minus ``vm.ensure_running``.
+
+        ``vm.ensure_running`` is executed separately by the unified driver as an
+        ``EnsureVmRunning`` task; the recipe is the remaining provision/deploy
+        components in their canonical order (this is exactly the recipe
+        ``_build_prelude_tasks`` builds for the prelude argv oracle).
         """
-        from controlplane_tool.infra.vm.proxmox_vm_adapter import ProxmoxVmOrchestrator
-
-        stack_request, _ = self._requests()
-        proxmox_orch = ProxmoxVmOrchestrator(repo_root=self.runner.paths.workspace_root)
-        return self._build_prelude_tasks(proxmox_orch, stack_request, resolve_host=False)
-
-    def _display_prelude_task_ids(self) -> list[str]:
-        return ["vm.ensure_running"] + [t.task_id for t in self._display_prelude_tasks()]
-
-    def _display_prelude_titles(self) -> list[str]:
-        return ["Ensure stack VM running (Proxmox)"] + [
-            t.title for t in self._display_prelude_tasks()
-        ]
-
-    def _skeleton(self) -> "tuple[list[EnsureVmRunning | _SkeletonStep], Workflow]":
-        """Task objects with None adapters — only task_id and title are valid here."""
-        r = self.request
-        stack_request, loadgen_request = self._requests()
-        sc = VmConfig(
-            name=stack_request.name or "",
-            cpus=stack_request.cpus,
-            memory=stack_request.memory,
-            disk=stack_request.disk,
+        prelude_components = tuple(
+            cid for cid in _PROXMOX_LOADTEST_PRELUDE_COMPONENTS if cid != "vm.ensure_running"
         )
-        lc = VmConfig(
-            name=loadgen_request.name or "",
-            cpus=loadgen_request.cpus,
-            memory=loadgen_request.memory,
-            disk=loadgen_request.disk,
+        recipe = build_scenario_recipe("proxmox-vm-loadtest")
+        return recipe.__class__(
+            name=recipe.name,
+            component_ids=prelude_components,
+            requires_managed_vm=recipe.requires_managed_vm,
         )
-        pre = [
-            EnsureVmRunning(task_id="vm.stack.ensure_running", title="Ensure stack VM running (Proxmox)", lifecycle=None, config=sc),  # type: ignore[arg-type]
-            EnsureVmRunning(task_id="vm.loadgen.ensure_running", title="Ensure loadgen VM running (Proxmox)", lifecycle=None, config=lc),  # type: ignore[arg-type]
-            _SkeletonStep(task_id="vm.stack.publish_ports", title="Publish Proxmox NAT ports"),
-        ]
-        wf = Workflow(
-            tasks=[
-                InstallK6(task_id="loadgen.install_k6", title="Install k6 on loadgen VM (Proxmox)", runner=None, remote_dir=None),  # type: ignore[arg-type]
-                RunK6(task_id="loadgen.run_k6", title="Run k6 loadtest (Proxmox)", runner=None, config=None, remote_dir=None),  # type: ignore[arg-type]
-                FetchVmResults(task_id="loadgen.fetch_results", title="Fetch k6 results from loadgen VM (Proxmox)", fetcher=None, remote_source=None, local_dest=None),  # type: ignore[arg-type]
-                CapturePrometheusSnapshot(task_id="metrics.prometheus_snapshot", title="Capture Prometheus snapshots (Proxmox)", client=None, queries=None, window=None, output_dir=None),  # type: ignore[arg-type]
-                WriteK6Report(task_id="loadtest.write_report", title="Write loadtest report (Proxmox)", data_dir=None, output_dir=None),  # type: ignore[arg-type]
-            ],
-            cleanup_tasks=(
-                [
-                    DestroyVm(task_id="vm.loadgen.destroy", title="Destroy loadgen VM (Proxmox)", lifecycle=None, info=None),  # type: ignore[arg-type]
-                    DestroyVm(task_id="vm.stack.destroy", title="Destroy stack VM (Proxmox)", lifecycle=None, info=None),  # type: ignore[arg-type]
-                ]
-                if getattr(r, "cleanup_vm", True)
-                else []
-            ),
+
+    def run(self, event_listener=None) -> None:
+        run_loadtest_flow(
+            runner=self.runner,
+            request=self.request,
+            setup=build_setup(self.runner, self.request),
+            recipe=self._recipe(),
+            adapter=self._adapter(),
+            event_listener=event_listener,
         )
-        return pre, wf
+
+    # ── prelude argv oracle support (consumed by the hard-invariant tests) ────
+    # These methods are independent of run(): they reproduce the legacy proxmox
+    # prelude CommandTasks (ansible/rsync/register rewrites) so the prelude argv
+    # golden (test_proxmox_prelude_argv.py) and the prelude workflow snapshot
+    # (test_proxmox_prelude_workflow.py) stay pinned. The unified driver builds
+    # the identical tasks via the adapter (ProxmoxConnectivity +
+    # prelude_special_handler/context_selector); this is the same assembly,
+    # surfaced here for the goldens.
 
     def _requests(self) -> tuple[VmRequest, VmRequest]:
         if self.request.vm is None:
@@ -175,22 +131,8 @@ class ProxmoxVmLoadtestPlan:
             raise ValueError("proxmox-vm-loadtest requires a loadgen VM request")
         return self.request.vm, self.request.loadgen_vm
 
-    # ── honest prelude Workflow (the structure executed by run()) ────────────────
-
     @property
     def prelude_tasks(self) -> list:
-        """Honest Tasks reproducing the legacy proxmox prelude recipe steps.
-
-        Built from the ``proxmox-vm-loadtest`` recipe filtered to
-        ``_PROXMOX_LOADTEST_PRELUDE_COMPONENTS``, applying the three proxmox
-        rewrites (ansible inventory, repo rsync, functions.register) so the
-        resulting CommandTask argv/env match the legacy recipe engine exactly. The
-        proxmox SSH endpoint is resolved through a ``ProxmoxVmOrchestrator``; in
-        ``run()`` this happens after the stack VM is ensured.
-
-        ``vm.ensure_running`` is run separately by ``run()`` as an
-        ``EnsureVmRunning`` task and is therefore NOT in this list.
-        """
         from controlplane_tool.infra.vm.proxmox_vm_adapter import ProxmoxVmOrchestrator
 
         stack_request, _ = self._requests()
@@ -199,11 +141,6 @@ class ProxmoxVmLoadtestPlan:
 
     @property
     def prelude_task_ids(self) -> list[str]:
-        """Ordered prelude task_ids, matching the legacy recipe step ids.
-
-        ``vm.ensure_running`` (run separately) is prepended so the list matches
-        the legacy recipe step ids exactly (see the oracle test).
-        """
         return ["vm.ensure_running"] + [t.task_id for t in self.prelude_tasks]
 
     def _build_prelude_tasks(
@@ -211,12 +148,10 @@ class ProxmoxVmLoadtestPlan:
     ) -> list:
         """Assemble the honest prelude Tasks against a (running) proxmox orch.
 
-        *resolve_host*: when True (the default, used by ``run()`` and the oracle)
-        the proxmox SSH endpoint / key / remote dir are resolved through the live
-        orchestrator (the stack VM must already be running). When False (used to
-        derive cheap display task_ids/titles without a running VM) placeholder
-        endpoint values are used — the TUI shows titles/task_ids, not resolved
-        commands, so the placeholders are never executed.
+        Mirrors exactly what the unified driver builds for the prelude: the
+        ``proxmox-vm-loadtest`` recipe minus ``vm.ensure_running``, with the
+        proxmox rewrites (ansible inventory / repo rsync / functions.register)
+        applied through ``ProxmoxConnectivity`` + special_handler/context_selector.
         """
         repo_root = self.runner.paths.workspace_root
         request = self.request
@@ -243,17 +178,6 @@ class ProxmoxVmLoadtestPlan:
             control_plane_endpoint=None,
         )
 
-        # Recipe = the proxmox prelude minus vm.ensure_running (run() does that separately).
-        prelude_components = tuple(
-            cid for cid in _PROXMOX_LOADTEST_PRELUDE_COMPONENTS if cid != "vm.ensure_running"
-        )
-        recipe = build_scenario_recipe("proxmox-vm-loadtest")
-        recipe = recipe.__class__(
-            name=recipe.name,
-            component_ids=prelude_components,
-            requires_managed_vm=recipe.requires_managed_vm,
-        )
-
         connectivity = ProxmoxConnectivity(
             orchestrator=proxmox_orch,
             request=stack_request,
@@ -264,14 +188,14 @@ class ProxmoxVmLoadtestPlan:
             remote_dir_value=remote_dir,
         )
 
-        # _Setup carries only context + vm_request for build_command_tasks; its lifecycle
-        # field is unused by build_command_tasks, so the default (multipass) setup is fine.
         setup = build_setup(self.runner, request)
-
         registered = {"done": False}
 
         def special_handler(operation):
-            if operation.operation_id.startswith("cli.fn_apply_selected") and request.scenario in LOADTEST_SCENARIOS:
+            if (
+                operation.operation_id.startswith("cli.fn_apply_selected")
+                and request.scenario in LOADTEST_SCENARIOS
+            ):
                 if not registered["done"]:
                     registered["done"] = True
                     return CallableTask(
@@ -289,7 +213,7 @@ class ProxmoxVmLoadtestPlan:
             self.runner,
             request,
             setup,
-            recipe,
+            self._recipe(),
             special_handler=special_handler,
             context_selector=context_selector,
             connectivity=connectivity,
@@ -328,452 +252,17 @@ class ProxmoxVmLoadtestPlan:
 
         return action
 
-    def _run_prelude_workflow(
-        self, prelude_tasks: list, *, event_listener, total_steps: int
-    ) -> int:
-        """Execute the honest prelude Tasks as a ``workflow_tasks.Workflow``.
-
-        Each honest Task (``CommandTask``/``CallableTask`` produced by
-        ``_build_prelude_tasks``) is wrapped in a ``CallableTask`` that emits the
-        ``running``/``success``/``failed`` ``ScenarioStepEvent`` around it, then the
-        wrappers are run through a ``Workflow`` — preserving ordered execution and
-        the wrapped failure-message format of the legacy ``_execute_steps`` path.
-
-        Returns the number of prelude tasks executed (the tail-event offset).
-        """
-        from controlplane_tool.e2e.e2e_runner import ScenarioStepEvent
-
-        request = self.request
-
-        def _step(task) -> ScenarioPlanStep:
-            return ScenarioPlanStep(
-                summary=task.title,
-                command=["python", "-c", f"# {task.task_id}"],
-                step_id=task.task_id,
-            )
-
-        def _emit(step_index, task, status, error=None) -> None:
-            if event_listener is None:
-                return
-            event_listener(
-                ScenarioStepEvent(
-                    step_index=step_index,
-                    total_steps=total_steps,
-                    step=_step(task),
-                    status=status,
-                    error=error,
-                )
-            )
-
-        def _wrapped(step_index, task) -> CallableTask:
-            def action() -> None:
-                _emit(step_index, task, "running")
-                try:
-                    task.run()
-                except Exception as exc:
-                    _emit(step_index, task, "failed", error=str(exc))
-                    raise RuntimeError(
-                        f"Scenario '{request.scenario}' failed at step "
-                        f"'{task.title}': {exc}"
-                    ) from exc
-                _emit(step_index, task, "success")
-
-            return CallableTask(task_id=task.task_id, title=task.title, action=action)
-
-        wrappers = [
-            _wrapped(step_index, task)
-            for step_index, task in enumerate(prelude_tasks, start=1)
-        ]
-        Workflow(tasks=wrappers).run()
-        return len(prelude_tasks)
-
-    def run(self, event_listener=None) -> None:
-        from controlplane_tool.e2e.two_vm_loadtest_runner import TwoVmLoadtestRunner
-        from controlplane_tool.infra.vm.proxmox_vm_adapter import ProxmoxVmOrchestrator
-
-        stack_request, _ = self._requests()
-        proxmox_orch = ProxmoxVmOrchestrator(repo_root=self.runner.paths.workspace_root)
-        stack_lifecycle = ProxmoxVmAdapter(proxmox_orch, credentials=stack_request)
-        total_steps = len(self.task_ids)
-
-        # The stack VM must be running before the honest prelude Tasks are built:
-        # _build_prelude_tasks resolves the proxmox SSH endpoint (host/port/key)
-        # eagerly. This ensure is a silent prerequisite (its own task identity is
-        # the tail's vm.stack.ensure_running, emitted there); the prelude events
-        # cover only the honest CommandTasks, so the tail offset == len(prelude).
-        stack_config = VmConfig(
-            name=stack_request.name or "",
-            cpus=stack_request.cpus,
-            memory=stack_request.memory,
-            disk=stack_request.disk,
-        )
-        prelude_offset = 0
-        try:
-            EnsureVmRunning(
-                task_id="vm.ensure_running",
-                title="Ensure stack VM running (Proxmox)",
-                lifecycle=stack_lifecycle,
-                config=stack_config,
-            ).run()
-            prelude_tasks = self._build_prelude_tasks(proxmox_orch, stack_request)
-            prelude_offset = self._run_prelude_workflow(
-                prelude_tasks, event_listener=event_listener, total_steps=total_steps
-            )
-        except Exception as exc:
-            cleanup_errors = self._cleanup_proxmox_requests(proxmox_orch)
-            if cleanup_errors:
-                raise RuntimeError(
-                    f"{exc}\n\nCleanup failed:\n" + "\n".join(cleanup_errors)
-                ) from exc
-            raise
-
-        run_dir_creator = TwoVmLoadtestRunner(
-            repo_root=self.runner.paths.workspace_root, vm=cast(Any, proxmox_orch)
-        )
-
-        try:
-            tail_tasks, cleanup_tasks = self._tail_tasks(
-                proxmox_orch=proxmox_orch,
-                stack_lifecycle=stack_lifecycle,
-                run_dir_creator=run_dir_creator,
-            )
-        except Exception as exc:
-            cleanup_errors = self._cleanup_proxmox_requests(proxmox_orch)
-            if cleanup_errors:
-                raise RuntimeError(
-                    f"{exc}\n\nCleanup failed:\n" + "\n".join(cleanup_errors)
-                ) from exc
-            raise
-
-        self._run_tail_tasks(
-            tail_tasks,
-            cleanup_tasks,
-            event_listener=event_listener,
-            offset=prelude_offset,
-            total_steps=total_steps,
-        )
-
-    def _cleanup_proxmox_requests(self, proxmox_orch) -> list[str]:
-        if not self.request.cleanup_vm:
-            return []
-        errors: list[str] = []
-        for vm_request in (self.request.loadgen_vm, self.request.vm):
-            if vm_request is None:
-                continue
-            try:
-                proxmox_orch.teardown(vm_request)
-            except Exception as exc:
-                errors.append(str(exc))
-        return errors
-
-    def _tail_step(self, task) -> ScenarioPlanStep:
-        return ScenarioPlanStep(
-            summary=task.title,
-            command=["python", "-c", f"# {task.task_id}"],
-            step_id=task.task_id,
-        )
-
-    def _emit_tail_event(
-        self,
-        event_listener,
-        *,
-        step_index: int,
-        total_steps: int,
-        task,
-        status: str,
-        error: str | None = None,
-    ) -> None:
-        if event_listener is None:
-            return
-        from controlplane_tool.e2e.e2e_runner import ScenarioStepEvent
-
-        event_listener(
-            ScenarioStepEvent(
-                step_index=step_index,
-                total_steps=total_steps,
-                step=self._tail_step(task),
-                status=status,  # type: ignore[arg-type]
-                error=error,
-            )
-        )
-
-    def _run_tail_task(
-        self,
-        task,
-        *,
-        step_index: int,
-        total_steps: int,
-        event_listener,
-    ) -> None:
-        self._emit_tail_event(
-            event_listener,
-            step_index=step_index,
-            total_steps=total_steps,
-            task=task,
-            status="running",
-        )
-        try:
-            with workflow_step(task_id=task.task_id, title=task.title):
-                task.run()
-        except BaseException as exc:
-            self._emit_tail_event(
-                event_listener,
-                step_index=step_index,
-                total_steps=total_steps,
-                task=task,
-                status="failed",
-                error=str(exc),
-            )
-            raise
-        self._emit_tail_event(
-            event_listener,
-            step_index=step_index,
-            total_steps=total_steps,
-            task=task,
-            status="success",
-        )
-
-    def _run_tail_tasks(
-        self,
-        tasks: list[_ActionTask],
-        cleanup_tasks: list[_ActionTask],
-        *,
-        event_listener,
-        offset: int,
-        total_steps: int,
-    ) -> None:
-        main_error: BaseException | None = None
-
-        for task_index, task in enumerate(tasks, start=offset + 1):
-            try:
-                self._run_tail_task(
-                    task,
-                    step_index=task_index,
-                    total_steps=total_steps,
-                    event_listener=event_listener,
-                )
-            except BaseException as exc:
-                main_error = exc
-                break
-
-        cleanup_errors: list[str] = []
-        cleanup_offset = offset + len(tasks)
-        for cleanup_index, task in enumerate(cleanup_tasks, start=cleanup_offset + 1):
-            try:
-                self._run_tail_task(
-                    task,
-                    step_index=cleanup_index,
-                    total_steps=total_steps,
-                    event_listener=event_listener,
-                )
-            except Exception as exc:
-                cleanup_errors.append(str(exc))
-
-        if main_error is not None:
-            if cleanup_errors:
-                combined = f"{main_error}\n\nCleanup errors:\n" + "\n".join(cleanup_errors)
-                raise RuntimeError(combined) from main_error
-            raise main_error
-
-        if cleanup_errors:
-            raise RuntimeError("Cleanup failed:\n" + "\n".join(cleanup_errors))
-
-    def _tail_tasks(
-        self,
-        *,
-        proxmox_orch,
-        stack_lifecycle: VmLifecycleAdapter,
-        run_dir_creator,
-    ) -> tuple[list[_ActionTask], list[_ActionTask]]:
-        request = self.request
-        stack_request, loadgen_request = self._requests()
-        loadgen_lifecycle = ProxmoxVmAdapter(proxmox_orch, credentials=loadgen_request)
-        [s_ensure_stack, s_ensure_loadgen, s_publish_ports], s_wf = self._skeleton()
-        [s_install_k6, s_run_k6, s_fetch, s_prom, s_report] = s_wf.tasks
-        s_destroy_loadgen, s_destroy_stack = s_wf.cleanup_tasks if s_wf.cleanup_tasks else (None, None)
-
-        state: dict[str, Any] = {}
-
-        stack_config = VmConfig(
-            name=stack_request.name or "",
-            cpus=stack_request.cpus,
-            memory=stack_request.memory,
-            disk=stack_request.disk,
-        )
-        loadgen_config = VmConfig(
-            name=loadgen_request.name or "",
-            cpus=loadgen_request.cpus,
-            memory=loadgen_request.memory,
-            disk=loadgen_request.disk,
-        )
-
-        ensure_stack = EnsureVmRunning(
-            task_id=s_ensure_stack.task_id,
-            title=s_ensure_stack.title,
-            lifecycle=stack_lifecycle,
-            config=stack_config,
-        )
-        ensure_loadgen = EnsureVmRunning(
-            task_id=s_ensure_loadgen.task_id,
-            title=s_ensure_loadgen.title,
-            lifecycle=loadgen_lifecycle,
-            config=loadgen_config,
-        )
-
-        def _ensure_stack() -> None:
-            state["stack_info"] = ensure_stack.run()
-
-        def _ensure_loadgen() -> None:
-            state["loadgen_info"] = ensure_loadgen.run()
-
-        def _publish_ports() -> None:
-            stack_guest_host = state["stack_info"].host
-            prometheus_host, prometheus_port = proxmox_orch.publish_port(
-                stack_request,
-                service="PROMETHEUS",
-                guest_port=TWO_VM_PROMETHEUS_NODE_PORT,
-            )
-            state["stack_guest_host"] = stack_guest_host
-            state["prometheus_host"] = prometheus_host
-            state["prometheus_port"] = prometheus_port
-
-        def _remote_paths():
-            if "remote_paths" not in state:
-                state["remote_paths"] = two_vm_remote_paths(
-                    state["loadgen_info"].home,
-                    payload_name=request.k6_payload.name if request.k6_payload is not None else None,
-                )
-            return state["remote_paths"]
-
-        def _run_dir():
-            if "run_dir" not in state:
-                state["run_dir"] = run_dir_creator._create_run_dir()  # noqa: SLF001
-            return state["run_dir"]
-
-        def _control_plane_url() -> str:
-            return two_vm_control_plane_url(stack_request, host=state["stack_guest_host"])
-
-        def _loadgen_runner():
-            if "loadgen_runner" not in state:
-                state["loadgen_runner"] = OrchestratorVmRunner(proxmox_orch, loadgen_request)
-            return state["loadgen_runner"]
-
-        def _k6_config() -> K6Config:
-            return make_loadtest_k6_config(
-                remote_paths=_remote_paths(),
-                control_plane_url=_control_plane_url(),
-                target_function=two_vm_target_function(request),
-                stages=two_vm_load_stages(request),
-                vus=request.k6_vus,
-                duration=request.k6_duration,
-            )
-
-        def _body() -> list:
-            if "body" not in state:
-                host, port = proxmox_orch.ssh_endpoint(loadgen_request)
-                state["body"] = build_loadgen_body_tasks(
-                    LoadgenBodyInputs(
-                        task_ids=(s_install_k6.task_id, s_run_k6.task_id, s_fetch.task_id,
-                                  s_prom.task_id, s_report.task_id),
-                        titles=(s_install_k6.title, s_run_k6.title, s_fetch.title,
-                                s_prom.title, s_report.title),
-                        runner=cast(Any, _loadgen_runner()),
-                        fetcher=VmFileFetcher(vm=proxmox_orch, request=loadgen_request),
-                        prometheus_client=HttpPrometheusClient(
-                            url=f"http://{state['prometheus_host']}:{state['prometheus_port']}"
-                        ),
-                        prometheus_queries=LOADTEST_PROMETHEUS_QUERIES,
-                        k6_config=_k6_config(),
-                        remote_dir=state["loadgen_info"].home,
-                        remote_summary_path=_remote_paths().summary_path,
-                        run_dir=_run_dir(),
-                        repo_root=self.runner.paths.workspace_root,
-                        shell=self.runner.shell,
-                        install_host=host,
-                        install_user=loadgen_request.user,
-                        install_private_key=proxmox_orch.ssh_private_key_path(loadgen_request),
-                        install_port=port,
-                    )
-                )
-            return state["body"]
-
-        def _install_k6() -> None:
-            _body()[0].run()
-
-        def _run_k6() -> None:
-            _body()[1].run()
-
-        def _fetch_results() -> None:
-            _body()[2].run()
-
-        def _capture_prometheus() -> None:
-            _body()[3].run()
-
-        def _write_report() -> None:
-            _body()[4].run()
-
-        def _destroy_loadgen() -> None:
-            if s_destroy_loadgen is not None and "loadgen_info" in state:
-                DestroyVm(
-                    task_id=s_destroy_loadgen.task_id,
-                    title=s_destroy_loadgen.title,
-                    lifecycle=loadgen_lifecycle,
-                    info=state["loadgen_info"],
-                ).run()
-            else:
-                proxmox_orch.teardown(loadgen_request)
-
-        def _destroy_stack() -> None:
-            if s_destroy_stack is not None and "stack_info" in state:
-                DestroyVm(
-                    task_id=s_destroy_stack.task_id,
-                    title=s_destroy_stack.title,
-                    lifecycle=stack_lifecycle,
-                    info=state["stack_info"],
-                ).run()
-            else:
-                proxmox_orch.teardown(stack_request)
-
-        tasks = [
-            _ActionTask(s_ensure_stack.task_id, s_ensure_stack.title, _ensure_stack),
-            _ActionTask(s_ensure_loadgen.task_id, s_ensure_loadgen.title, _ensure_loadgen),
-            _ActionTask(s_publish_ports.task_id, s_publish_ports.title, _publish_ports),
-            _ActionTask(s_install_k6.task_id, s_install_k6.title, _install_k6),
-            _ActionTask(s_run_k6.task_id, s_run_k6.title, _run_k6),
-            _ActionTask(s_fetch.task_id, s_fetch.title, _fetch_results),
-            _ActionTask(s_prom.task_id, s_prom.title, _capture_prometheus),
-            _ActionTask(s_report.task_id, s_report.title, _write_report),
-        ]
-        cleanup_tasks = (
-            [
-                _ActionTask(s_destroy_loadgen.task_id, s_destroy_loadgen.title, _destroy_loadgen),
-                _ActionTask(s_destroy_stack.task_id, s_destroy_stack.title, _destroy_stack),
-            ]
-            if request.cleanup_vm and s_destroy_loadgen is not None and s_destroy_stack is not None
-            else []
-        )
-        return tasks, cleanup_tasks
-
 
 def build_proxmox_vm_loadtest_plan(
     runner: "E2eRunner",
     request: E2eRequest,
 ) -> ProxmoxVmLoadtestPlan:
     from controlplane_tool.scenario.catalog import resolve_scenario
-    from controlplane_tool.scenario.scenarios._workflow_assembly import (
-        workflow_display_steps,
-    )
 
     scenario = resolve_scenario("proxmox-vm-loadtest")
-    plan = ProxmoxVmLoadtestPlan(
+    return ProxmoxVmLoadtestPlan(
         scenario=scenario,
         request=request,
         steps=[],
         runner=runner,
     )
-    # Lightweight display steps derived from the honest prelude Tasks (NOT the
-    # legacy recipe engine), so CLI dry-run still renders commands. Built with
-    # resolve_host=False so no live VM is needed; vm.ensure_running is prepended
-    # to match the recipe order. The TUI uses phase_titles for display.
-    plan.steps = workflow_display_steps(plan._display_prelude_tasks())  # noqa: SLF001
-    return plan

--- a/tools/controlplane/tests/test_loadtest_adapter.py
+++ b/tools/controlplane/tests/test_loadtest_adapter.py
@@ -27,3 +27,20 @@ def test_multipass_adapter_extra_steps_are_empty() -> None:
     assert adapter.extra_steps(FlowPhase.BEFORE_LOADGEN, ctx) == []
     assert adapter.extra_step_ids(FlowPhase.AFTER_STACK_READY) == []
     assert adapter.extra_step_ids(FlowPhase.BEFORE_LOADGEN) == []
+
+
+def test_multipass_adapter_noop_capabilities() -> None:
+    adapter = MultipassLoadtestAdapter(runner=SimpleNamespace(), request=SimpleNamespace())
+    ctx = RunContext()
+    assert adapter.emits_step_events() is False
+    assert adapter.cleanup_on_failure(RuntimeError("x")) == []
+    assert adapter.prelude_special_handler(ctx) is None
+    assert adapter.prelude_context_selector(ctx) is None
+    assert adapter.extra_step_titles(FlowPhase.AFTER_STACK_READY) == []
+    assert adapter.extra_step_titles(FlowPhase.BEFORE_LOADGEN) == []
+
+
+def test_multipass_adapter_register_functions_is_callable() -> None:
+    """register_functions must exist and be callable (behavior tested via driver in Task 4)."""
+    adapter = MultipassLoadtestAdapter(runner=SimpleNamespace(), request=SimpleNamespace())
+    assert callable(adapter.register_functions)

--- a/tools/controlplane/tests/test_loadtest_adapter.py
+++ b/tools/controlplane/tests/test_loadtest_adapter.py
@@ -44,3 +44,147 @@ def test_multipass_adapter_register_functions_is_callable() -> None:
     """register_functions must exist and be callable (behavior tested via driver in Task 4)."""
     adapter = MultipassLoadtestAdapter(runner=SimpleNamespace(), request=SimpleNamespace())
     assert callable(adapter.register_functions)
+
+
+def test_multipass_connectivity_for_returns_static_connectivity() -> None:
+    from controlplane_tool.scenario.connectivity import MultipassConnectivity
+
+    adapter = MultipassLoadtestAdapter(runner=SimpleNamespace(), request=SimpleNamespace())
+    assert isinstance(adapter.connectivity, MultipassConnectivity)
+    # Same static MultipassConnectivity regardless of ctx/resolve_host.
+    assert adapter.connectivity_for(None, resolve_host=False) is adapter.connectivity
+    assert adapter.connectivity_for(RunContext(), resolve_host=True) is adapter.connectivity
+
+
+# ── ProxmoxLoadtestAdapter ──────────────────────────────────────────────────
+
+
+class _FakeProxmoxVmOrchestrator:
+    """Minimal proxmox orchestrator double mirroring the fakes in
+    test_proxmox_vm_loadtest_plan.py."""
+
+    def __init__(self, repo_root=None) -> None:
+        self.repo_root = repo_root
+        self.torn_down: list[str] = []
+        self.published: list[tuple[str, int]] = []
+
+    def remote_project_dir(self, request):
+        return "/home/ubuntu/nanofaas"
+
+    def ssh_endpoint(self, request):
+        return "10.0.0.10", 2222
+
+    def ssh_private_key_path(self, request):
+        return Path("/tmp/proxmox_key")
+
+    def publish_port(self, request, *, service, guest_port):
+        self.published.append((service, guest_port))
+        return "127.0.0.1", 30090
+
+    def teardown(self, request):
+        self.torn_down.append(request.name)
+
+
+def _proxmox_adapter(orch, *, cleanup_vm=True):
+    from controlplane_tool.scenario.loadtest_adapter import ProxmoxLoadtestAdapter
+
+    request = SimpleNamespace(
+        scenario="proxmox-vm-loadtest",
+        cleanup_vm=cleanup_vm,
+        vm=SimpleNamespace(name="proxmox-stack", user="ubuntu"),
+        loadgen_vm=SimpleNamespace(name="proxmox-loadgen", user="ubuntu"),
+    )
+    runner = SimpleNamespace(
+        paths=SimpleNamespace(workspace_root=Path("/repo")),
+        manifest_root=None,
+    )
+    adapter = ProxmoxLoadtestAdapter(runner=runner, request=request)
+    adapter._proxmox_orch = orch  # inject the fake (no live proxmox)
+    return adapter
+
+
+def test_proxmox_adapter_title_suffix() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    assert adapter.title_suffix == " (Proxmox)"
+
+
+def test_proxmox_adapter_emits_step_events() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    assert adapter.emits_step_events() is True
+
+
+def test_proxmox_adapter_register_functions_is_noop() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    assert adapter.register_functions(RunContext()) is None
+
+
+def test_proxmox_adapter_extra_step_ids_and_titles() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    assert adapter.extra_step_ids(FlowPhase.BEFORE_LOADGEN) == ["vm.stack.publish_ports"]
+    assert adapter.extra_step_ids(FlowPhase.AFTER_STACK_READY) == []
+    assert adapter.extra_step_titles(FlowPhase.BEFORE_LOADGEN) == ["Publish Proxmox NAT ports"]
+    assert adapter.extra_step_titles(FlowPhase.AFTER_STACK_READY) == []
+
+
+def test_proxmox_adapter_extra_steps_after_stack_ready_empty() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    assert adapter.extra_steps(FlowPhase.AFTER_STACK_READY, RunContext()) == []
+
+
+def test_proxmox_connectivity_for_placeholder_when_not_resolving() -> None:
+    from controlplane_tool.scenario.connectivity import ProxmoxConnectivity
+
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    conn = adapter.connectivity_for(None, resolve_host=False)
+    assert isinstance(conn, ProxmoxConnectivity)
+    assert conn.host == "<proxmox-host>"
+    assert conn.port == 0
+    assert conn.key is None
+    assert conn.remote_dir_value == "/home/ubuntu/nanofaas"
+
+
+def test_proxmox_connectivity_for_resolves_endpoint() -> None:
+    from controlplane_tool.scenario.connectivity import ProxmoxConnectivity
+
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    conn = adapter.connectivity_for(RunContext(), resolve_host=True)
+    assert isinstance(conn, ProxmoxConnectivity)
+    assert conn.host == "10.0.0.10"
+    assert conn.port == 2222
+    assert conn.key == Path("/tmp/proxmox_key")
+
+
+def test_proxmox_loadgen_install_endpoint_includes_port() -> None:
+    adapter = _proxmox_adapter(_FakeProxmoxVmOrchestrator())
+    ep = adapter.loadgen_install_endpoint(RunContext())
+    assert ep.host == "10.0.0.10"
+    assert ep.port == 2222
+    assert ep.user == "ubuntu"
+    assert ep.private_key == Path("/tmp/proxmox_key")
+
+
+def test_proxmox_before_loadgen_publishes_prometheus_and_sets_url() -> None:
+    orch = _FakeProxmoxVmOrchestrator()
+    adapter = _proxmox_adapter(orch)
+    ctx = RunContext()
+    steps = adapter.extra_steps(FlowPhase.BEFORE_LOADGEN, ctx)
+    assert [s.task_id for s in steps] == ["vm.stack.publish_ports"]
+    steps[0].run()
+    assert ("PROMETHEUS", 30090) in orch.published
+    assert ctx.prometheus_url == "http://127.0.0.1:30090"
+    assert adapter.prometheus_url(ctx) == "http://127.0.0.1:30090"
+
+
+def test_proxmox_cleanup_on_failure_tears_down_loadgen_then_stack() -> None:
+    orch = _FakeProxmoxVmOrchestrator()
+    adapter = _proxmox_adapter(orch, cleanup_vm=True)
+    errors = adapter.cleanup_on_failure(RuntimeError("boom"))
+    assert errors == []
+    assert orch.torn_down == ["proxmox-loadgen", "proxmox-stack"]
+
+
+def test_proxmox_cleanup_on_failure_respects_cleanup_vm_false() -> None:
+    orch = _FakeProxmoxVmOrchestrator()
+    adapter = _proxmox_adapter(orch, cleanup_vm=False)
+    assert adapter.cleanup_on_failure(RuntimeError("boom")) == []
+    assert orch.torn_down == []

--- a/tools/controlplane/tests/test_loadtest_flow.py
+++ b/tools/controlplane/tests/test_loadtest_flow.py
@@ -47,11 +47,12 @@ def test_run_loadtest_flow_orders_phases_and_populates_context(monkeypatch) -> N
         def prepare_loadgen(self, ctx): events.append("prepare")
         def create_run_dir(self): return Path("/tmp/run")
         def extra_steps(self, phase, ctx): events.append(f"extra:{phase.name}"); return []
+        def emits_step_events(self): return False
+        def register_functions(self, ctx): events.append("register")
 
     monkeypatch.setattr(mod, "_ensure_vm", lambda task_id, title, lifecycle, config: events.append(task_id) or FakeInfo())
     monkeypatch.setattr(mod, "_build_prelude_tasks", lambda runner, request, setup, recipe, connectivity: [])
     monkeypatch.setattr(mod, "_run_workflow", lambda tasks, cleanup_tasks=None: events.append("workflow"))
-    monkeypatch.setattr(mod, "_register_functions", lambda runner, request, setup, ctx: events.append("register"))
     monkeypatch.setattr(mod, "_build_loadgen_body", lambda runner, request, adapter, ctx: events.append("body") or [])
     monkeypatch.setattr(mod, "_two_vm_remote_paths_for", lambda request, ctx: object())
 
@@ -130,3 +131,201 @@ def test_static_phase_titles_match_two_vm(monkeypatch) -> None:
             "Write loadtest report", "Destroy loadgen VM", "Destroy stack VM",
         ]
     )
+
+
+# ── Task 4: adapter opt-in capabilities (multipass path stays unchanged) ─────
+
+
+def _emitting_setup_request():
+    from pathlib import Path
+    setup = type("S", (), {"vm_config": object(), "context": object()})()
+    request = type("R", (), {"cleanup_vm": False,
+                             "loadgen_vm": type("L", (), {"name": "lg", "cpus": 1, "memory": "1G", "disk": "5G", "user": "ubuntu"})()})()
+    return setup, request, Path
+
+
+def test_emitting_adapter_emits_running_then_success_per_task(monkeypatch) -> None:
+    """When emits_step_events() is True, the driver emits running->success per
+    executed task with sequential step_index and a constant total_steps."""
+    from pathlib import Path
+    from controlplane_tool.scenario import loadtest_flow as mod
+
+    setup, request, _ = _emitting_setup_request()
+
+    class FakeInfo:
+        host = "10.0.0.9"
+        home = "/home/ubuntu"
+
+    class FakeTask:
+        def __init__(self, task_id, title):
+            self.task_id = task_id
+            self.title = title
+
+        def run(self):
+            return None
+
+    class FakeAdapter:
+        title_suffix = " (Fake)"
+        connectivity = object()
+
+        def stack_lifecycle(self): return "stack-lc"
+        def loadgen_lifecycle(self): return "loadgen-lc"
+        def loadgen_install_endpoint(self, ctx):
+            from controlplane_tool.scenario.loadtest_adapter import InstallEndpoint
+            return InstallEndpoint(host="1.1.1.1", user="ubuntu", private_key=None, port=None)
+        def loadgen_runner(self, ctx): return object()
+        def fetcher(self, ctx): return object()
+        def control_plane_url(self, ctx): return "http://cp:8080"
+        def prometheus_url(self, ctx): return "http://prom:9090"
+        def prepare_loadgen(self, ctx): pass
+        def create_run_dir(self): return Path("/tmp/run")
+        def extra_steps(self, phase, ctx): return []
+        def extra_step_ids(self, phase): return []
+        def extra_step_titles(self, phase): return []
+        def emits_step_events(self): return True
+        def cleanup_on_failure(self, error): return []
+        def prelude_special_handler(self, ctx): return None
+        def prelude_context_selector(self, ctx): return None
+        def register_functions(self, ctx): pass
+
+    # Pin the static plan length so total_steps is deterministic.
+    monkeypatch.setattr(mod, "loadtest_flow_task_ids",
+                        lambda **kw: ["t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9"])
+    monkeypatch.setattr(mod, "_ensure_vm_task",
+                        lambda task_id, title, lifecycle, config: FakeTask(task_id, title))
+    monkeypatch.setattr(mod, "_build_prelude_tasks",
+                        lambda runner, request, setup, recipe, connectivity, special_handler=None, context_selector=None:
+                        [FakeTask("prelude.a", "Prelude A")])
+    monkeypatch.setattr(mod, "_build_loadgen_body",
+                        lambda runner, request, adapter, ctx:
+                        [FakeTask(tid, tid) for tid in ("loadgen.install_k6", "loadgen.run_k6",
+                                                        "loadgen.fetch_results",
+                                                        "metrics.prometheus_snapshot",
+                                                        "loadtest.write_report")])
+    monkeypatch.setattr(mod, "_two_vm_remote_paths_for", lambda request, ctx: object())
+
+    events = []
+    mod.run_loadtest_flow(runner=object(), request=request, setup=setup, recipe=object(),
+                          adapter=FakeAdapter(), event_listener=events.append)
+
+    # Constant total_steps.
+    assert {e.total_steps for e in events} == {9}
+    # Every executed task emits running then success.
+    seq = [(e.step_index, e.step.step_id, e.status) for e in events]
+    statuses = [s for _, _, s in seq]
+    assert all(s in ("running", "success") for s in statuses)
+    # Indices are sequential, paired running->success.
+    indices = [idx for idx, _, _ in seq]
+    pairs = list(zip(indices[::2], indices[1::2]))
+    assert all(a == b for a, b in pairs)  # running/success share index
+    distinct_indices = [a for a, _ in pairs]
+    assert distinct_indices == list(range(1, len(distinct_indices) + 1))
+    # prelude task comes first, then ensure-stack at index 2.
+    running = [(idx, sid) for idx, sid, st in seq if st == "running"]
+    assert running[0] == (1, "prelude.a")
+    assert ("vm.stack.ensure_running" in [sid for _, sid in running])
+
+
+def test_emitting_adapter_wraps_prelude_failure_with_cleanup(monkeypatch) -> None:
+    """When a prelude-region task raises and cleanup_on_failure returns errors,
+    the driver wraps the message with the scenario format and includes cleanup."""
+    import pytest
+    from pathlib import Path
+    from controlplane_tool.scenario import loadtest_flow as mod
+
+    setup, request, _ = _emitting_setup_request()
+    request.scenario = "fake-scenario"
+
+    class FakeInfo:
+        host = "10.0.0.9"
+        home = "/home/ubuntu"
+
+    class BoomTask:
+        task_id = "prelude.boom"
+        title = "Boom step"
+
+        def run(self):
+            raise RuntimeError("kaboom")
+
+    class FakeAdapter:
+        title_suffix = ""
+        connectivity = object()
+
+        def stack_lifecycle(self): return "stack-lc"
+        def loadgen_lifecycle(self): return "loadgen-lc"
+        def loadgen_install_endpoint(self, ctx): return None
+        def loadgen_runner(self, ctx): return object()
+        def fetcher(self, ctx): return object()
+        def control_plane_url(self, ctx): return "http://cp:8080"
+        def prometheus_url(self, ctx): return "http://prom:9090"
+        def prepare_loadgen(self, ctx): pass
+        def create_run_dir(self): return Path("/tmp/run")
+        def extra_steps(self, phase, ctx): return []
+        def extra_step_ids(self, phase): return []
+        def extra_step_titles(self, phase): return []
+        def emits_step_events(self): return True
+        def cleanup_on_failure(self, error): return ["teardown failed: nope"]
+        def prelude_special_handler(self, ctx): return None
+        def prelude_context_selector(self, ctx): return None
+        def register_functions(self, ctx): pass
+
+    monkeypatch.setattr(mod, "loadtest_flow_task_ids", lambda **kw: ["t1", "t2"])
+    monkeypatch.setattr(mod, "_ensure_vm_task",
+                        lambda task_id, title, lifecycle, config:
+                        type("T", (), {"task_id": task_id, "title": title, "run": lambda self: FakeInfo()})())
+    monkeypatch.setattr(mod, "_build_prelude_tasks",
+                        lambda runner, request, setup, recipe, connectivity, special_handler=None, context_selector=None:
+                        [BoomTask()])
+
+    with pytest.raises(RuntimeError) as exc_info:
+        mod.run_loadtest_flow(runner=object(), request=request, setup=setup, recipe=object(),
+                              adapter=FakeAdapter(), event_listener=lambda e: None)
+
+    msg = str(exc_info.value)
+    assert "Scenario 'fake-scenario' failed at step 'Boom step'" in msg
+    assert "kaboom" in msg
+    assert "teardown failed: nope" in msg
+
+
+def test_static_plan_injects_extra_step_ids_and_titles_aligned(monkeypatch) -> None:
+    """extra_step_ids and extra_step_titles are injected at the same BEFORE_LOADGEN
+    position so the dry-run task_ids and phase_titles stay length-aligned."""
+    from controlplane_tool.scenario import loadtest_flow as mod
+
+    class FakeTask:
+        def __init__(self, task_id, title):
+            self.task_id = task_id
+            self.title = title
+
+    prelude = [FakeTask("vm.provision_base", "Provision base"),
+               FakeTask("repo.sync_to_vm", "Sync project to VM")]
+    monkeypatch.setattr(mod, "_prelude_static_tasks",
+                        lambda runner, request, setup, recipe, connectivity: prelude)
+    monkeypatch.setattr(mod, "_prelude_static_ids",
+                        lambda runner, request, setup, recipe, connectivity: [t.task_id for t in prelude])
+
+    class FakeAdapter:
+        title_suffix = ""
+        connectivity = object()
+
+        def extra_step_ids(self, phase):
+            if phase is FlowPhase.BEFORE_LOADGEN:
+                return ["vm.stack.publish_ports"]
+            return []
+
+        def extra_step_titles(self, phase):
+            if phase is FlowPhase.BEFORE_LOADGEN:
+                return ["Publish Proxmox NAT ports"]
+            return []
+
+    ids = mod.loadtest_flow_task_ids(runner=object(), request=object(), setup=object(),
+                                     recipe=object(), adapter=FakeAdapter())
+    titles = mod.loadtest_flow_phase_titles(runner=object(), request=object(), setup=object(),
+                                            recipe=object(), adapter=FakeAdapter())
+    assert len(ids) == len(titles)
+    assert "vm.stack.publish_ports" in ids
+    assert "Publish Proxmox NAT ports" in titles
+    assert ids.index("vm.stack.publish_ports") == titles.index("Publish Proxmox NAT ports")
+    # Positioned right after ensure-loadgen, before the body.
+    assert ids.index("vm.loadgen.ensure_running") < ids.index("vm.stack.publish_ports")
+    assert ids.index("vm.stack.publish_ports") < ids.index("loadgen.install_k6")

--- a/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
@@ -586,6 +586,151 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
     ]
 
 
+def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
+    """Characterization test: pins teardown order + raised error when a TAIL task fails.
+
+    When ``cleanup_vm=True`` and a tail task raises, ``_run_tail_tasks`` runs
+    the cleanup_tasks (DestroyVm action wrappers) which call
+    ``proxmox_orch.teardown`` in loadgen-first, stack-second order.  The
+    original exception is re-raised unwrapped (no message formatting added by
+    the tail path).
+    """
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from workflow_tasks.shell import RecordingShell
+    from controlplane_tool.e2e.e2e_models import E2eRequest
+    from controlplane_tool.e2e.e2e_runner import E2eRunner
+    from controlplane_tool.infra.vm.vm_models import VmRequest
+    from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
+    import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
+
+    destroy_calls: list[str] = []
+
+    class FakeProxmoxVmOrchestrator:
+        def __init__(self, repo_root):
+            self.repo_root = repo_root
+
+        def publish_port(self, request, *, service, guest_port):
+            return "127.0.0.1", 30090
+
+        def ssh_endpoint(self, request):
+            return "127.0.0.1", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+
+        def teardown(self, request):
+            # Called only in the else-branch of _destroy_loadgen/_destroy_stack
+            # (when loadgen_info / stack_info is NOT yet in state).
+            destroy_calls.append(("teardown", request.name))
+
+    class FakeTwoVmLoadtestRunner:
+        def __init__(self, repo_root, vm):
+            self.repo_root = repo_root
+            self.vm = vm
+
+        def _create_run_dir(self):
+            return Path("/tmp/proxmox-run")
+
+    class FakeEnsureVmRunning:
+        def __init__(self, *, task_id, title, lifecycle, config):
+            self.task_id = task_id
+            self.title = title
+
+        def run(self):
+            return SimpleNamespace(host="10.0.0.10", home="/home/ubuntu")
+
+    class FakeTask:
+        def __init__(self, *, task_id, title, **kwargs):
+            self.task_id = task_id
+            self.title = title
+            self.result = SimpleNamespace(started_at=1.0, ended_at=2.0)
+
+        def run(self):
+            return Path("/tmp/proxmox-result")
+
+    class FakeDestroyVm:
+        """DestroyVm replacement that records which VM was destroyed."""
+
+        def __init__(self, *, task_id, title, lifecycle=None, info=None, **kwargs):
+            self.task_id = task_id
+            self.title = title
+
+        def run(self):
+            # task_id is e.g. "vm.loadgen.destroy" or "vm.stack.destroy"
+            destroy_calls.append(self.task_id)
+
+    class FailingFakeTask:
+        """A FakeTask whose .run() raises RuntimeError("boom")."""
+
+        def __init__(self, *, task_id, title, **kwargs):
+            self.task_id = task_id
+            self.title = title
+            self.result = SimpleNamespace(started_at=1.0, ended_at=2.0)
+
+        def run(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "controlplane_tool.infra.vm.proxmox_vm_adapter.ProxmoxVmOrchestrator",
+        FakeProxmoxVmOrchestrator,
+    )
+    monkeypatch.setattr(
+        "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
+        FakeTwoVmLoadtestRunner,
+    )
+    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
+    monkeypatch.setattr(proxmox_plan, "DestroyVm", FakeDestroyVm)
+
+    # Make the loadgen.run_k6 task raise; all others are silent no-ops.
+    def fake_build_loadgen_body_tasks(inputs):
+        tasks = []
+        for tid, title in zip(inputs.task_ids, inputs.titles):
+            if tid == "loadgen.run_k6":
+                tasks.append(FailingFakeTask(task_id=tid, title=title))
+            else:
+                tasks.append(FakeTask(task_id=tid, title=title))
+        return tasks
+
+    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+
+    # Silent no-op honest prelude (bypass real SSH resolution).
+    monkeypatch.setattr(
+        proxmox_plan.ProxmoxVmLoadtestPlan,
+        "_build_prelude_tasks",
+        lambda self, proxmox_orch, stack_request, *, resolve_host=True: [
+            CallableTask(task_id="prelude.noop", title="Prelude no-op", action=lambda: None)
+        ],
+    )
+
+    runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
+    request = E2eRequest(
+        scenario="proxmox-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="proxmox", name="proxmox-stack"),
+        loadgen_vm=VmRequest(lifecycle="proxmox", name="proxmox-loadgen"),
+        cleanup_vm=True,
+    )
+    plan = proxmox_plan.ProxmoxVmLoadtestPlan(
+        scenario=resolve_scenario("proxmox-vm-loadtest"),
+        request=request,
+        steps=[],
+        runner=runner,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        plan.run(event_listener=lambda e: None)
+
+    # The tail path re-raises the original exception without any wrapping.
+    assert str(exc_info.value) == "boom"
+    # cleanup_tasks ran DestroyVm in loadgen-first, stack-second order (pinned).
+    # Both VMs have state entries (ensure tasks ran before run_k6 failed), so
+    # _destroy_loadgen/_destroy_stack take the DestroyVm branch, not teardown().
+    assert destroy_calls == ["vm.loadgen.destroy", "vm.stack.destroy"]
+
+
 def test_proxmox_loadgen_install_uses_runplaybook_not_bash() -> None:
     """Verify the loadgen body is built via the shared builder (which uses install_k6_task /
     ansible-based install internally), not by constructing InstallK6 directly."""

--- a/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
@@ -454,6 +454,138 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
     assert ("proxmox-loadgen", "proxmox-loadgen") in ensure_lifecycles
 
 
+def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
+    """Characterization test: pins the EXACT ScenarioStepEvent sequence emitted by
+    ProxmoxVmLoadtestPlan.run(event_listener=...) BEFORE any refactor.
+
+    The expected sequence was captured from the unchanged production code and must
+    NOT be adjusted to match a refactored version — it IS the contract.
+    """
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from workflow_tasks.shell import RecordingShell
+    from controlplane_tool.e2e.e2e_models import E2eRequest
+    from controlplane_tool.e2e.e2e_runner import E2eRunner
+    from controlplane_tool.infra.vm.vm_models import VmRequest
+    from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
+    import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
+
+    class FakeProxmoxVmOrchestrator:
+        def __init__(self, repo_root):
+            self.repo_root = repo_root
+
+        def publish_port(self, request, *, service, guest_port):
+            return "127.0.0.1", 30090
+
+        def ssh_endpoint(self, request):
+            return "127.0.0.1", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+
+        def teardown(self, request):
+            return None
+
+    class FakeTwoVmLoadtestRunner:
+        def __init__(self, repo_root, vm):
+            self.repo_root = repo_root
+            self.vm = vm
+
+        def _create_run_dir(self):
+            return Path("/tmp/proxmox-run")
+
+    class FakeEnsureVmRunning:
+        def __init__(self, *, task_id, title, lifecycle, config):
+            self.task_id = task_id
+            self.title = title
+
+        def run(self):
+            return SimpleNamespace(host="10.0.0.10", home="/home/ubuntu")
+
+    class FakeTask:
+        def __init__(self, *, task_id, title, **kwargs):
+            self.task_id = task_id
+            self.title = title
+            self.result = SimpleNamespace(started_at=1.0, ended_at=2.0)
+
+        def run(self):
+            return Path("/tmp/proxmox-result")
+
+    monkeypatch.setattr(
+        "controlplane_tool.infra.vm.proxmox_vm_adapter.ProxmoxVmOrchestrator",
+        FakeProxmoxVmOrchestrator,
+    )
+    monkeypatch.setattr(
+        "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
+        FakeTwoVmLoadtestRunner,
+    )
+    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
+    monkeypatch.setattr(proxmox_plan, "DestroyVm", FakeTask)
+
+    def fake_build_loadgen_body_tasks(inputs):
+        return [FakeTask(task_id=tid, title=title) for tid, title in zip(inputs.task_ids, inputs.titles)]
+
+    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+
+    def fake_build_prelude_tasks(self, proxmox_orch, stack_request, *, resolve_host=True):
+        return [
+            CallableTask(
+                task_id="prelude.noop",
+                title="Prelude no-op",
+                action=lambda: None,
+            )
+        ]
+
+    monkeypatch.setattr(
+        proxmox_plan.ProxmoxVmLoadtestPlan,
+        "_build_prelude_tasks",
+        fake_build_prelude_tasks,
+    )
+
+    runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
+    request = E2eRequest(
+        scenario="proxmox-vm-loadtest",
+        runtime="java",
+        vm=VmRequest(lifecycle="proxmox", name="proxmox-stack"),
+        loadgen_vm=VmRequest(lifecycle="proxmox", name="proxmox-loadgen"),
+        cleanup_vm=False,
+    )
+    plan = proxmox_plan.ProxmoxVmLoadtestPlan(
+        scenario=resolve_scenario("proxmox-vm-loadtest"),
+        request=request,
+        steps=[],
+        runner=runner,
+    )
+    events = []
+
+    plan.run(event_listener=events.append)
+
+    seq = [(e.step_index, e.step.step_id, e.status) for e in events]
+    assert {e.total_steps for e in events} == {len(plan.task_ids)}
+    assert seq == [
+        (1, "prelude.noop", "running"),
+        (1, "prelude.noop", "success"),
+        (2, "vm.stack.ensure_running", "running"),
+        (2, "vm.stack.ensure_running", "success"),
+        (3, "vm.loadgen.ensure_running", "running"),
+        (3, "vm.loadgen.ensure_running", "success"),
+        (4, "vm.stack.publish_ports", "running"),
+        (4, "vm.stack.publish_ports", "success"),
+        (5, "loadgen.install_k6", "running"),
+        (5, "loadgen.install_k6", "success"),
+        (6, "loadgen.run_k6", "running"),
+        (6, "loadgen.run_k6", "success"),
+        (7, "loadgen.fetch_results", "running"),
+        (7, "loadgen.fetch_results", "success"),
+        (8, "metrics.prometheus_snapshot", "running"),
+        (8, "metrics.prometheus_snapshot", "success"),
+        (9, "loadtest.write_report", "running"),
+        (9, "loadtest.write_report", "success"),
+    ]
+
+
 def test_proxmox_loadgen_install_uses_runplaybook_not_bash() -> None:
     """Verify the loadgen body is built via the shared builder (which uses install_k6_task /
     ansible-based install internally), not by constructing InstallK6 directly."""

--- a/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_proxmox_vm_loadtest_plan.py
@@ -55,7 +55,11 @@ def test_proxmox_vm_loadtest_plan_task_ids_include_platform_prefix() -> None:
     ids = plan.task_ids
 
     required = [
-        "vm.ensure_running",
+        # B3b: canonical execution-order emission via run_loadtest_flow names the
+        # stack-ensure step "vm.stack.ensure_running" (matching two-vm), not the
+        # legacy bespoke "vm.ensure_running". The load-bearing invariant —
+        # functions.register < vm.stack.publish_ports < loadgen.install_k6 — holds.
+        "vm.stack.ensure_running",
         "vm.provision_base",
         "repo.sync_to_vm",
         "registry.ensure_container",
@@ -107,6 +111,7 @@ def test_proxmox_vm_loadtest_plan_skips_destroy_when_no_cleanup(tmp_path) -> Non
     from controlplane_tool.e2e.e2e_models import E2eRequest
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
+    from controlplane_tool.scenario.loadtest_flow import RunContext, _destroy_tasks
     from controlplane_tool.scenario.scenarios.proxmox_vm_loadtest import build_proxmox_vm_loadtest_plan
 
     runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
@@ -118,8 +123,9 @@ def test_proxmox_vm_loadtest_plan_skips_destroy_when_no_cleanup(tmp_path) -> Non
         cleanup_vm=False,
     )
     plan = build_proxmox_vm_loadtest_plan(runner=runner, request=request)
-    _, wf = plan._skeleton()
-    assert wf.cleanup_tasks == []
+    # B3b: cleanup is driven by the unified driver's _destroy_tasks, which returns
+    # no DestroyVm tasks when cleanup_vm is False.
+    assert _destroy_tasks(plan._adapter(), RunContext(), request) == []
 
 
 def test_e2e_runner_plan_returns_proxmox_vm_loadtest_plan(tmp_path) -> None:
@@ -152,6 +158,7 @@ def test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails(monkeypatc
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
     from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario import loadtest_flow
     from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
     from controlplane_tool.scenario.scenarios.proxmox_vm_loadtest import ProxmoxVmLoadtestPlan
 
@@ -169,6 +176,17 @@ def test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails(monkeypatc
         def connection_host(self, request):
             return "10.0.0.10"
 
+        # B3b: the driver resolves proxmox connectivity (resolve_host=True) before
+        # building the prelude, so the orch must answer the SSH-endpoint queries.
+        def remote_project_dir(self, request):
+            return f"/home/{request.user or 'ubuntu'}/nanofaas"
+
+        def ssh_endpoint(self, request):
+            return "10.0.0.10", 2222
+
+        def ssh_private_key_path(self, request):
+            return None
+
         def teardown(self, request):
             torn_down.append(request.name)
 
@@ -177,10 +195,12 @@ def test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails(monkeypatc
         FakeProxmoxVmOrchestrator,
     )
 
-    # Make the honest prelude FAIL via a synthetic honest Task (bypasses real
-    # _build_prelude_tasks / SSH resolution): run() must run the honest prelude
-    # tasks, so the failure here proves it does — and trigger NAT/VM cleanup.
-    def fake_build_prelude_tasks(self, proxmox_orch, stack_request, *, resolve_host=True):
+    # B3b: run() routes through run_loadtest_flow, which builds the prelude via the
+    # shared driver (loadtest_flow._build_prelude_tasks). Make the prelude FAIL via
+    # a synthetic honest Task; the unified driver's emitting failure-cleanup path
+    # must trigger adapter.cleanup_on_failure -> proxmox teardown of both VMs.
+    def fake_build_prelude_tasks(runner, request, setup, recipe, connectivity,
+                                 special_handler=None, context_selector=None):
         return [
             CallableTask(
                 task_id="prelude.fail",
@@ -189,9 +209,7 @@ def test_proxmox_vm_loadtest_cleans_up_vms_and_nat_when_prelude_fails(monkeypatc
             )
         ]
 
-    monkeypatch.setattr(
-        ProxmoxVmLoadtestPlan, "_build_prelude_tasks", fake_build_prelude_tasks
-    )
+    monkeypatch.setattr(loadtest_flow, "_build_prelude_tasks", fake_build_prelude_tasks)
 
     runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
     request = E2eRequest(
@@ -223,6 +241,7 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
     from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario import loadtest_flow
     from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
     import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
 
@@ -232,6 +251,9 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
 
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
+
+        def remote_project_dir(self, request):
+            return f"/home/{request.user or 'ubuntu'}/nanofaas"
 
         def ssh_endpoint(self, request):
             return "127.0.0.1", 2222
@@ -275,18 +297,19 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
         "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
         FakeTwoVmLoadtestRunner,
     )
-    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
-    monkeypatch.setattr(proxmox_plan, "DestroyVm", FakeTask)
+    # B3b: run() routes through run_loadtest_flow; patch the driver-owned symbols.
+    monkeypatch.setattr(loadtest_flow, "EnsureVmRunning", FakeEnsureVmRunning)
+    monkeypatch.setattr(loadtest_flow, "DestroyVm", FakeTask)
 
     def fake_build_loadgen_body_tasks(inputs):
         return [FakeTask(task_id=tid, title=title) for tid, title in zip(inputs.task_ids, inputs.titles)]
 
-    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+    monkeypatch.setattr("workflow_tasks.build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
 
-    # The honest prelude is a single synthetic no-op Task (bypasses real
-    # _build_prelude_tasks / SSH resolution). run() must execute it, so the tail
-    # events start AFTER it.
-    def fake_build_prelude_tasks(self, proxmox_orch, stack_request, *, resolve_host=True):
+    # The prelude is a single synthetic no-op Task (bypasses real prelude / SSH
+    # resolution). run() must execute it, so the tail events start AFTER it.
+    def fake_build_prelude_tasks(runner, request, setup, recipe, connectivity,
+                                 special_handler=None, context_selector=None):
         return [
             CallableTask(
                 task_id="prelude.noop",
@@ -295,11 +318,7 @@ def test_proxmox_vm_loadtest_tail_events_start_after_prelude(monkeypatch, tmp_pa
             )
         ]
 
-    monkeypatch.setattr(
-        proxmox_plan.ProxmoxVmLoadtestPlan,
-        "_build_prelude_tasks",
-        fake_build_prelude_tasks,
-    )
+    monkeypatch.setattr(loadtest_flow, "_build_prelude_tasks", fake_build_prelude_tasks)
 
     runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
     request = E2eRequest(
@@ -343,6 +362,8 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
     from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario import loadtest_flow
+    import controlplane_tool.infra.vm_lifecycle_adapters as vm_lifecycle_adapters
     import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
 
     adapter_credentials: list[str] = []
@@ -354,6 +375,9 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
 
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
+
+        def remote_project_dir(self, request):
+            return f"/home/{request.user or 'ubuntu'}/nanofaas"
 
         def ssh_endpoint(self, request):
             return "127.0.0.1", 2222
@@ -409,19 +433,23 @@ def test_proxmox_vm_loadtest_uses_separate_lifecycle_credentials_for_loadgen(
         "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
         FakeTwoVmLoadtestRunner,
     )
-    monkeypatch.setattr(proxmox_plan, "ProxmoxVmAdapter", fake_proxmox_adapter)
-    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
+    # B3b: lifecycles + ensure tasks are now built inside the shared driver
+    # (loadtest_flow) and the proxmox adapter (which imports ProxmoxVmAdapter from
+    # controlplane_tool.infra.vm_lifecycle_adapters). Patch them where the driver
+    # and adapter resolve them.
+    monkeypatch.setattr(vm_lifecycle_adapters, "ProxmoxVmAdapter", fake_proxmox_adapter)
+    monkeypatch.setattr(loadtest_flow, "EnsureVmRunning", FakeEnsureVmRunning)
 
     def fake_build_loadgen_body_tasks(inputs):
         return [FakeTask(task_id=tid, title=title) for tid, title in zip(inputs.task_ids, inputs.titles)]
 
-    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
-    # This test exercises the tail lifecycle credentials, not the prelude; use an
-    # empty honest prelude so run() skips real SSH-resolving prelude building.
+    monkeypatch.setattr("workflow_tasks.build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+    # This test exercises the lifecycle credentials, not the prelude; use an empty
+    # prelude so run() skips real SSH-resolving prelude building.
     monkeypatch.setattr(
-        proxmox_plan.ProxmoxVmLoadtestPlan,
+        loadtest_flow,
         "_build_prelude_tasks",
-        lambda self, proxmox_orch, stack_request, *, resolve_host=True: [],
+        lambda runner, request, setup, recipe, connectivity, special_handler=None, context_selector=None: [],
     )
 
     runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
@@ -469,6 +497,7 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
     from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario import loadtest_flow
     from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
     import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
 
@@ -478,6 +507,9 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
 
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
+
+        def remote_project_dir(self, request):
+            return f"/home/{request.user or 'ubuntu'}/nanofaas"
 
         def ssh_endpoint(self, request):
             return "127.0.0.1", 2222
@@ -521,15 +553,17 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
         "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
         FakeTwoVmLoadtestRunner,
     )
-    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
-    monkeypatch.setattr(proxmox_plan, "DestroyVm", FakeTask)
+    # B3b: run() routes through run_loadtest_flow; patch the driver-owned symbols.
+    monkeypatch.setattr(loadtest_flow, "EnsureVmRunning", FakeEnsureVmRunning)
+    monkeypatch.setattr(loadtest_flow, "DestroyVm", FakeTask)
 
     def fake_build_loadgen_body_tasks(inputs):
         return [FakeTask(task_id=tid, title=title) for tid, title in zip(inputs.task_ids, inputs.titles)]
 
-    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+    monkeypatch.setattr("workflow_tasks.build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
 
-    def fake_build_prelude_tasks(self, proxmox_orch, stack_request, *, resolve_host=True):
+    def fake_build_prelude_tasks(runner, request, setup, recipe, connectivity,
+                                 special_handler=None, context_selector=None):
         return [
             CallableTask(
                 task_id="prelude.noop",
@@ -538,11 +572,7 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
             )
         ]
 
-    monkeypatch.setattr(
-        proxmox_plan.ProxmoxVmLoadtestPlan,
-        "_build_prelude_tasks",
-        fake_build_prelude_tasks,
-    )
+    monkeypatch.setattr(loadtest_flow, "_build_prelude_tasks", fake_build_prelude_tasks)
 
     runner = E2eRunner(repo_root=Path("/repo"), shell=RecordingShell(), manifest_root=tmp_path)
     request = E2eRequest(
@@ -564,6 +594,11 @@ def test_proxmox_event_sequence_is_pinned(monkeypatch, tmp_path) -> None:
 
     seq = [(e.step_index, e.step.step_id, e.status) for e in events]
     assert {e.total_steps for e in events} == {len(plan.task_ids)}
+    # B3b: canonical execution-order emission produced by run_loadtest_flow's
+    # emitting path (prelude -> ensure-stack -> ensure-loadgen -> publish-ports ->
+    # loadgen body), with a single ScenarioStepEvent pair per task in execution
+    # order (no separate prelude-then-tail re-emission). See the B3b plan:
+    # docs/superpowers/plans/*loadtest-scenario-unification* (Task 6).
     assert seq == [
         (1, "prelude.noop", "running"),
         (1, "prelude.noop", "success"),
@@ -603,6 +638,7 @@ def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
     from controlplane_tool.e2e.e2e_runner import E2eRunner
     from controlplane_tool.infra.vm.vm_models import VmRequest
     from controlplane_tool.scenario.catalog import resolve_scenario
+    from controlplane_tool.scenario import loadtest_flow
     from controlplane_tool.scenario.scenarios._workflow_assembly import CallableTask
     import controlplane_tool.scenario.scenarios.proxmox_vm_loadtest as proxmox_plan
 
@@ -614,6 +650,9 @@ def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
 
         def publish_port(self, request, *, service, guest_port):
             return "127.0.0.1", 30090
+
+        def remote_project_dir(self, request):
+            return f"/home/{request.user or 'ubuntu'}/nanofaas"
 
         def ssh_endpoint(self, request):
             return "127.0.0.1", 2222
@@ -681,8 +720,9 @@ def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
         "controlplane_tool.e2e.two_vm_loadtest_runner.TwoVmLoadtestRunner",
         FakeTwoVmLoadtestRunner,
     )
-    monkeypatch.setattr(proxmox_plan, "EnsureVmRunning", FakeEnsureVmRunning)
-    monkeypatch.setattr(proxmox_plan, "DestroyVm", FakeDestroyVm)
+    # B3b: run() routes through run_loadtest_flow; patch the driver-owned symbols.
+    monkeypatch.setattr(loadtest_flow, "EnsureVmRunning", FakeEnsureVmRunning)
+    monkeypatch.setattr(loadtest_flow, "DestroyVm", FakeDestroyVm)
 
     # Make the loadgen.run_k6 task raise; all others are silent no-ops.
     def fake_build_loadgen_body_tasks(inputs):
@@ -694,13 +734,13 @@ def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
                 tasks.append(FakeTask(task_id=tid, title=title))
         return tasks
 
-    monkeypatch.setattr(proxmox_plan, "build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
+    monkeypatch.setattr("workflow_tasks.build_loadgen_body_tasks", fake_build_loadgen_body_tasks)
 
-    # Silent no-op honest prelude (bypass real SSH resolution).
+    # Silent no-op prelude (bypass real SSH resolution).
     monkeypatch.setattr(
-        proxmox_plan.ProxmoxVmLoadtestPlan,
+        loadtest_flow,
         "_build_prelude_tasks",
-        lambda self, proxmox_orch, stack_request, *, resolve_host=True: [
+        lambda runner, request, setup, recipe, connectivity, special_handler=None, context_selector=None: [
             CallableTask(task_id="prelude.noop", title="Prelude no-op", action=lambda: None)
         ],
     )
@@ -733,11 +773,16 @@ def test_proxmox_tail_failure_tears_down_vms(monkeypatch, tmp_path) -> None:
 
 def test_proxmox_loadgen_install_uses_runplaybook_not_bash() -> None:
     """Verify the loadgen body is built via the shared builder (which uses install_k6_task /
-    ansible-based install internally), not by constructing InstallK6 directly."""
+    ansible-based install internally), not by constructing InstallK6 directly.
+
+    B3b: proxmox now routes run() through run_loadtest_flow, so the loadgen body is
+    built by the shared driver (loadtest_flow._build_loadgen_body). Asserting against
+    the driver source preserves the invariant (build_loadgen_body_tasks present,
+    InstallK6 construction absent)."""
     import inspect
 
-    from controlplane_tool.scenario.scenarios import proxmox_vm_loadtest
+    from controlplane_tool.scenario import loadtest_flow
 
-    source = inspect.getsource(proxmox_vm_loadtest.ProxmoxVmLoadtestPlan._tail_tasks)
+    source = inspect.getsource(loadtest_flow._build_loadgen_body)
     assert "build_loadgen_body_tasks(" in source
     assert "InstallK6(" not in source

--- a/tools/controlplane/tests/test_two_vm_loadtest_plan.py
+++ b/tools/controlplane/tests/test_two_vm_loadtest_plan.py
@@ -97,12 +97,13 @@ def test_two_vm_run_uploads_k6_script_to_loadgen() -> None:
 def test_two_vm_run_registers_functions_on_control_plane() -> None:
     """run() must register the selected functions, else k6 invokes a non-existent
     function (400) and the required Prometheus dispatch metrics have no data.
-    After the B3a refactor, _register_functions (which uses RegisterFunctions) lives
-    in the shared run_loadtest_flow driver.
+    After the B3b reroute, multipass registration lives in the adapter's
+    MultipassLoadtestAdapter.register_functions (which uses RegisterFunctions),
+    invoked by the shared run_loadtest_flow driver via adapter.register_functions(ctx).
     """
     import inspect
 
-    from controlplane_tool.scenario import loadtest_flow
+    from controlplane_tool.scenario import loadtest_adapter
 
-    flow_source = inspect.getsource(loadtest_flow)
-    assert "RegisterFunctions" in flow_source
+    adapter_source = inspect.getsource(loadtest_adapter)
+    assert "RegisterFunctions" in adapter_source


### PR DESCRIPTION
## What
Second stage of the **B3 final collapse**. Routes the proxmox loadtest scenario through the unified `run_loadtest_flow` driver + a new `ProxmoxLoadtestAdapter`, retiring proxmox's bespoke orchestration (`_run_prelude_workflow`/`_run_tail_tasks`/`_tail_tasks`/`_skeleton`/`_ActionTask`/`_cleanup_proxmox_requests`/`_register_functions_action`/`_display_prelude_*` — **~511 lines, proxmox file 779 → 268**). two-vm and azure are untouched (azure = B3c).

## Approach: characterization-first (your call)
Because proxmox **can't be validated on real hardware**, Phase 1 pinned its current behavior the argv golden doesn't cover, BEFORE touching it:
- `test_proxmox_event_sequence_is_pinned` — the full `ScenarioStepEvent (step_index, step_id, status)` sequence + `total_steps`;
- `test_proxmox_tail_failure_tears_down_vms` — the **two distinct cleanup paths** (prelude failure → wrapped message + raw teardown; body/tail failure → unwrapped error + `DestroyVm` loadgen→stack).

Then the driver was generalized (opt-in `ScenarioStepEvent` emission + failure-cleanup wrapper + adapter-supplied recipe/special_handler/context_selector/register + `extra_step_titles` + `connectivity_for(ctx, resolve_host)`), `ProxmoxLoadtestAdapter` added, and proxmox routed — guarded by those characterization tests + the argv golden.

## Behavior preservation
- **`test_proxmox_prelude_argv.py` and `test_proxmox_prelude_workflow.py` untouched (empty diff) and green** — the core proxmox argv contract (kept `_build_prelude_tasks`/`prelude_tasks` for them).
- **two-vm + azure: empty diff** (scenarios untouched); two-vm goldens green; the multipass driver path is provably byte-identical (`emits_step_events()` False → exactly the B3a native path).
- task-id ordering invariant (`functions.register < vm.stack.publish_ports < loadgen.install_k6`) holds; failure-cleanup characterization holds.
- **Authorized cosmetic change** (your decision): proxmox now emits events in **execution order** (canonical) instead of its prior prelude-then-re-emit quirk; the event-sequence characterization test was updated to the canonical sequence (same step set, same `total_steps`, same success/failure semantics).

Subagent-driven (7 tasks), per-task spec/behavior reviews + a rigorous whole-fold review = **Approved** (all hard invariants verified against main; no test made vacuous). Also removed dead `_register_functions` and retargeted its two-vm guard to the adapter.

## Test Plan
- [x] `uv run --project tools/controlplane pytest tools/controlplane/tests -q` → **1170 passed**
- [x] argv + prelude-workflow goldens: empty diff, green
- [x] two-vm + azure scenarios: empty diff vs main
- [x] ruff clean
- [ ] **Real-VM: NOT possible for proxmox (no hardware)** — ships argv-golden + characterization-guarded, **unvalidated on a live Proxmox**. multipass two-vm unaffected.

Spec: `docs/superpowers/specs/2026-06-07-loadtest-b3-final-collapse-design.md`. Plan: `docs/superpowers/plans/2026-06-07-loadtest-b3b-proxmox-fold.md`. Next: **B3c** (azure → unified flow, gains provisioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)